### PR TITLE
APM-301181: Improve guessing threading

### DIFF
--- a/libnettracer/src/cpp/localsock.h
+++ b/libnettracer/src/cpp/localsock.h
@@ -2,10 +2,10 @@
 
 #include <spdlog/fwd.h>
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <thread>
 #include <utility>
 
 struct sockaddr_in;
@@ -34,6 +34,10 @@ public:
     bool start();
     bool stop();
 
+    bool running() const {
+        return serverRunning() && clientRunning();
+    }
+
     tcp_info getTCPInfo();
     inline uint16_t getClientPort() const {
         return clientPort;
@@ -43,7 +47,14 @@ public:
     static inline const int serverPort = 1234;
 
 private:
-    std::thread serverThread;
+    bool serverRunning() const {
+        return serverThreadReturn.valid();
+    }
+    bool clientRunning() const {
+        return static_cast<bool>(connection);
+    }
+
+    std::future<bool> serverThreadReturn;
     SocketFD connection = {nullptr, nullptr};
     uint16_t clientPort = 0;
 };

--- a/libnettracer/src/cpp/localsock.h
+++ b/libnettracer/src/cpp/localsock.h
@@ -44,7 +44,10 @@ public:
     }
 
     static inline const char* serverAddress = "127.0.0.2";
-    static inline const int serverPort = 1234;
+    uint16_t getServerPort() const {
+        return serverPort;
+    }
+    void randomizeServerPort();
 
 private:
     bool serverRunning() const {
@@ -56,19 +59,20 @@ private:
 
     std::future<bool> serverThreadReturn;
     SocketFD connection = {nullptr, nullptr};
+    uint16_t serverPort = 1234;
     uint16_t clientPort = 0;
 };
 
 namespace detail {
 
-uint16_t connectSendClose(char msg);
-std::pair<SocketFD, uint16_t> connectSendKeep(int reps);
+uint16_t connectSendClose(char msg, uint16_t port);
+std::pair<SocketFD, uint16_t> connectSendKeep(int reps, uint16_t port);
 
 SocketFD createSocket();
 void setsockoptLinger(int fd);
 void setsockoptNodelay(int fd);
 void setsockoptReuseaddr(int fd);
-sockaddr_in createSocketAddress(int fd);
+sockaddr_in createSocketAddress(int fd, uint16_t port);
 
 void connectSocket(int fd, sockaddr_in* socketAddress);
 void bindListenOnSocket(int fd, sockaddr_in* socketAddress);

--- a/libnettracer/src/cpp/localsock6.cpp
+++ b/libnettracer/src/cpp/localsock6.cpp
@@ -38,7 +38,7 @@ bool ClientSock6::setRemoteServerAndPort(const std::string& serverIp, uint16_t t
 	remoteServerInfo = *res;
 	sockaddr_in6* addr = (sockaddr_in6*)(remoteServerInfo.ai_addr);
 
-	LOG_DEBUG("RemoteAddressInfo  addr={:s}",  printIpAddr(addr));
+	LOG_DEBUG("RemoteAddressInfo addr={:s}", printIpAddr(addr));
 	return true;
 }
 

--- a/libnettracer/src/cpp/localsock6.cpp
+++ b/libnettracer/src/cpp/localsock6.cpp
@@ -6,7 +6,10 @@
 #include <cstdlib>
 #include <fcntl.h>
 #include <fstream>
+#include <netinet/in.h>
 #include <regex>
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 

--- a/libnettracer/src/cpp/localsock6.h
+++ b/libnettracer/src/cpp/localsock6.h
@@ -2,10 +2,7 @@
 
 #include <cstdint>
 #include <netdb.h>
-#include <netinet/in.h>
 #include <string>
-#include <sys/types.h>
-#include <sys/socket.h>
 
 // client for guessing offsets specific to IPv6
 class ClientSock6 {

--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -309,7 +309,7 @@ bool guess(int status_fd) {
 			status.offset_rtt >= thresholdTcpSock || status.offset_rtt_var >= thresholdTcpSock
 		) {
 			logger->error("overflow while guessing {:d}, bailing out", status.what);
-			break;
+			return false;
 		}
 	}
 	return true;

--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -23,9 +23,8 @@ extern "C" {
 static ino_t own_net_ns() {
 	struct stat statbuf;
 	int ret = stat("/proc/self/ns/net", &statbuf);
-	if (ret != 0) {
-		LOG_ERROR("stat");
-		exit(-1);
+	if (ret) {
+		throw std::runtime_error{"stat failed"};
 	}
 	return statbuf.st_ino;
 }

--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -33,7 +33,16 @@ inline const int thresholdTcpSock = 2500; // Fields outside inet_sock are stored
 }
 
 bool OffsetGuessing::guess(int status_fd) {
-	return makeGuessingAttempt(status_fd);
+	const unsigned maxAttempts = 3;
+	for (unsigned i = 0; i < maxAttempts; ++i) {
+		if (makeGuessingAttempt(status_fd)) {
+			return true;
+		}
+		else {
+			LOG_WARN("Guessing attempt #{:d} failed", i+1);
+		}
+	}
+	return false;
 }
 
 #define GUESS_SIMPLE_FIELD(field, str, next) guessSimpleField(status.field, expected.field, status.offset_##field, status, str, next)

--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -60,6 +60,7 @@ bool guess(int status_fd) {
 
 			std::this_thread::sleep_for(interval);
 			localsock.stop();
+			localsock.randomizeServerPort();
 			if (localsock.start()) {
 				ok = true;
 				break;
@@ -321,7 +322,7 @@ std::optional<field_values> getExpectedValues(LocalSock& localsock, const Client
 	field_values expected;
 	expected.saddr = 0x0100007F;                   // 127.0.0.1
 	expected.daddr = 0x0200007F;                   // 127.0.0.2
-	expected.dport = htons(LocalSock::serverPort);
+	expected.dport = htons(localsock.getServerPort());
 	expected.sport = htons(localsock.getClientPort());
 	expected.netns = own_net_ns();
 	clientsock6.getDAddress(expected.daddr6);

--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -180,7 +180,12 @@ bool OffsetGuessing::makeGuessingAttempt(int status_fd) {
 		}
 		if (overflowOccurred()) {
 			logger->error("overflow while guessing {:d}, bailing out", status.what);
-			return true;
+			if (status.what == GUESS_FIELD_RTT) {
+				// allow failure for RTT
+				status.offset_rtt = status.offset_rtt_var = 0;
+				return true;
+			}
+			return false;
 		}
 	}
 	return true;

--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -1,13 +1,8 @@
 #include "offsetguess.h"
 
-extern "C" {
-#include "bpf_program/nettracer-bpf.h"
-}
 #include "bpf_generic/bpf_loading.h"
 #include "bpf_generic/bpf_wrapper.h"
 #include "bpf_generic/log.h"
-#include "localsock.h"
-#include "localsock6.h"
 
 #include <fmt/core.h>
 
@@ -20,7 +15,9 @@ extern "C" {
 #include <unistd.h>
 #include <utility>
 
-static ino_t own_net_ns() {
+namespace {
+
+ino_t own_net_ns() {
 	struct stat statbuf;
 	int ret = stat("/proc/self/ns/net", &statbuf);
 	if (ret) {
@@ -29,13 +26,20 @@ static ino_t own_net_ns() {
 	return statbuf.st_ino;
 }
 
-bool guess(int status_fd) {
-	auto logger{logging::getLogger()};
+// Offset thresholds
+inline const int thresholdInetSock = 1500; // Don't go over that limit when guessing offsets for fields in inet_sock
+inline const int thresholdTcpSock = 2500; // Fields outside inet_sock are stored much farther
 
-	// Don't go over that limit when guessing offsets for fields in inet_sock
-	const int thresholdInetSock = 1500;
-	// Fields outside inet_sock are stored much farther
-	const int thresholdTcpSock = 2500;
+}
+
+bool OffsetGuessing::guess(int status_fd) {
+	return makeGuessingAttempt(status_fd);
+}
+
+#define GUESS_SIMPLE_FIELD(field, str, next) guessSimpleField(status.field, expected.field, status.offset_##field, status, str, next)
+
+bool OffsetGuessing::makeGuessingAttempt(int status_fd) {
+	logger = logging::getLogger();
 
 	uint32_t zero = 0;
 	int max_retries = 100;
@@ -49,19 +53,16 @@ bool guess(int status_fd) {
 	logger->debug("guess thread pid:{:d}", pid_tgid);
 
 	// prepare server ipv4 and client ipv6 on this thread
-	auto maybeLocalsock = detail::startLocalSock();
-	if (!maybeLocalsock) {
+	localsock = detail::startLocalSock();
+	if (!localsock) {
 		return false;
 	}
-	LocalSock& localsock = *maybeLocalsock;
 
-	ClientSock6 client6;
-	client6.readLocalInterface();
-	client6.setRemoteServerAndPort();
+	client6 = detail::prepareClient6();
 
 	// create or update status entry in map - signal that we are starting guessing
 	bpf::BPFMapsWrapper mapsWrapper;
-	struct guess_status_t status = {};
+	status = {};
 	status.state = GUESS_STATE_CHECKING;
 	status.pid_tgid = pid_tgid;
 	if (!mapsWrapper.updateElement(status_fd, &zero, &status)) {
@@ -73,7 +74,7 @@ bool guess(int status_fd) {
 	// prepare values used to verify that we are at right offset
 	field_values expected;
 	try {
-		auto expectedOpt{detail::getExpectedValues(localsock, client6)};
+		auto expectedOpt{getExpectedValues()};
 		if (!expectedOpt) {
 			return false;
 		}
@@ -84,23 +85,20 @@ bool guess(int status_fd) {
 		return false;
 	}
 
-	// RTT guessing config
-	const unsigned rttMaxAttempts{10}; // at max that many offsets may be verified
-	const unsigned rttRequiredReps{3}; // value at an offset must match with the expected value at least that many times in a row
 	unsigned rttCurrentAttempts{0};
 	unsigned rttCurrentReps{0};
 
 	// in loop below we need a swich to select connect trigger from IPv4 to IPv6 - we start with IPv4
-	bool guessIpv6 = false;
+	bool guessIPv6 = false;
 	while (true) {
 		logger->trace("guess status, poking {:s} with state:{:d} what:{:d}",
-			(guessIpv6?"ipv6":"ipv4"),
+			(guessIPv6?"ipv6":"ipv4"),
 			status.state, status.what
 		);
-		if (guessIpv6) {
+		if (guessIPv6) {
 			client6.pokeRemoteServerAndPort();
 		} else {
-			(void)localsock.getTCPInfo();
+			(void)localsock->getTCPInfo();
 		}
 		// check what we got from bpf in status record
 		if (!mapsWrapper.lookupElement(status_fd, &zero, &status)) {
@@ -122,157 +120,41 @@ bool guess(int status_fd) {
 
 		switch (status.what) {
 		case GUESS_FIELD_SADDR:
-			if (status.saddr == expected.saddr) {
-				logger->debug("Source address offset: {:#010x}", status.offset_saddr);
-				status.what = GUESS_FIELD_DADDR;
-			} else {
-				status.offset_saddr++;
-				status.saddr = expected.saddr;
-			}
-			status.state = GUESS_STATE_CHECKING;
+			GUESS_SIMPLE_FIELD(saddr, "Source address", GUESS_FIELD_DADDR);
 			break;
 		case GUESS_FIELD_DADDR:
-			if (status.daddr == expected.daddr) {
-				logger->debug("Destination address offset: {:#010x}", status.offset_daddr);
-				status.what = GUESS_FIELD_FAMILY;
-			} else {
-				status.offset_daddr++;
-				status.daddr = expected.daddr;
-			}
-			status.state = GUESS_STATE_CHECKING;
+			GUESS_SIMPLE_FIELD(daddr, "Destination address", GUESS_FIELD_FAMILY);
 			break;
 		case GUESS_FIELD_FAMILY:
-			if (status.family == expected.family) {
-				logger->debug("Family offset: {:#010x}", status.offset_family);
-				status.what = GUESS_FIELD_SPORT;
-			} else {
-				status.offset_family++;
-				status.family = expected.family;
-			}
-			status.state = GUESS_STATE_CHECKING;
+			GUESS_SIMPLE_FIELD(family, "Family", GUESS_FIELD_SPORT);
 			break;
 		case GUESS_FIELD_SPORT:
-			if (status.sport == expected.sport) {
-				logger->debug("Source port offset: {:#010x}", status.offset_sport);
-				status.what = GUESS_FIELD_DPORT;
-			} else {
-				status.offset_sport++;
-				status.sport = expected.sport;
-			}
-			status.state = GUESS_STATE_CHECKING;
+			GUESS_SIMPLE_FIELD(sport, "Source port", GUESS_FIELD_DPORT);
 			break;
 		case GUESS_FIELD_DPORT:
-			if (status.dport == expected.dport) {
-				logger->debug("Destination port offset: {:#010x}", status.offset_dport);
-				status.what = GUESS_FIELD_NETNS;
-			} else {
-				status.offset_dport++;
-				status.dport = expected.dport;
-			}
-			status.state = GUESS_STATE_CHECKING;
+			GUESS_SIMPLE_FIELD(dport, "Destination port", GUESS_FIELD_NETNS);
 			break;
 		case GUESS_FIELD_NETNS:
-			if (status.netns == expected.netns) {
-				logger->debug("Network namespace offset: {:#010x}", status.offset_netns);
-				status.what = GUESS_FIELD_DADDR_IPV6;
-				guessIpv6 = true;
-			} else {
-				status.offset_ino++;
-				if (status.err != 0 || status.offset_ino >= thresholdInetSock) {
-					status.offset_ino = 0;
-					status.offset_netns++;
-				}
+			guessNetns();
+			if (status.what == GUESS_FIELD_DADDR_IPV6) {
+				guessIPv6 = true;
 			}
-			status.state = GUESS_STATE_CHECKING;
 			break;
 		case GUESS_FIELD_DADDR_IPV6:
-			{
-				auto ipv6_equal = [](uint32_t a[4], uint32_t b[4])->bool {
-					for (int i = 0; i < 4; ++i) {
-						if(a[i] != b[i]) {
-							return false;
-						}
-					}
-					return true;
-				};
-				if (ipv6_equal(status.daddr_ipv6, expected.daddr6)) {
-					logger->debug("IPv6 daddress offset: {:#010x}", status.offset_daddr_ipv6);
-					status.what = GUESS_FIELD_SEGS_IN;
-					guessIpv6 = false;
-					// values specified below are placed somewhere below this value (actually, below inet_sock), so let's initialize their offsets
-					status.offset_segs_in = status.offset_segs_out = status.offset_rtt = status.offset_rtt_var = status.offset_daddr_ipv6 + sizeof(status.daddr_ipv6);
-				} else {
-					memcpy(&(status.daddr_ipv6), &(expected.daddr6), sizeof(expected.daddr6));
-					logger->trace("Check IPv6 daddress offset: {:#010x}", status.offset_daddr_ipv6);
-					status.offset_daddr_ipv6++;
-				}
+			guessDAddrIPv6();
+			if (status.what == GUESS_FIELD_SEGS_IN) {
+				guessIPv6 = false;
 			}
-			status.state = GUESS_STATE_CHECKING;
 			break;
 		case GUESS_FIELD_SEGS_IN:
-			if (status.segs_in == expected.segs_in) {
-				logger->debug("Segs in offset: {:#010x}", status.offset_segs_in);
-				status.what = GUESS_FIELD_SEGS_OUT;
-			} else {
-				status.offset_segs_in++;
-				status.segs_in = expected.segs_in;
-			}
-			status.state = GUESS_STATE_CHECKING;
+			GUESS_SIMPLE_FIELD(segs_in, "Segs in", GUESS_FIELD_SEGS_OUT);
 			break;
 		case GUESS_FIELD_SEGS_OUT:
-			if (status.segs_out == expected.segs_out) {
-				logger->debug("Segs out offset: {:#010x}", status.offset_segs_out);
-				status.what = GUESS_FIELD_RTT;
-			} else {
-				status.offset_segs_out++;
-				status.segs_out = expected.segs_out;
-				status.state = GUESS_STATE_CHECKING;
-			}
+			GUESS_SIMPLE_FIELD(segs_out, "Segs out", GUESS_FIELD_RTT);
 			break;
 		case GUESS_FIELD_RTT:
-			if (status.rtt == expected.rtt && status.rtt_var == expected.rtt_var) {
-				if (++rttCurrentReps == rttRequiredReps) {
-					logger->debug("RTT offset: {:#010x}", status.offset_rtt);
-					logger->debug("RTT var offset: {:#010x}", status.offset_rtt_var);
-					status.state = GUESS_STATE_READY;
-				} else {
-					// reload expected RTT
-					if (!localsock.stopClient() || !localsock.startClient()) {
-						logger->error("Couldn't restart client for RTT guessing");
-						return false;
-					}
-					try {
-						auto expectedOpt{detail::getExpectedValues(localsock, client6)};
-						if (!expectedOpt) {
-							return false;
-						}
-						expected = *expectedOpt;
-					}
-					catch (const std::runtime_error& ex) {
-						logger->error(ex.what());
-						return false;
-					}
-					status.rtt = expected.rtt;
-					status.rtt_var = expected.rtt_var;
-					status.state = GUESS_STATE_CHECKING;
-				}
-			} else {
-				if (rttCurrentReps > 0) {
-					logger->debug("Skipping offset {:#010x}; RTT, RTT var values don't match anymore - found: {:d}, {:d}, expected: {:d}, {:d}",
-					status.offset_rtt, status.rtt, status.rtt_var, expected.rtt, expected.rtt_var);
-					if (++rttCurrentAttempts == rttMaxAttempts) {
-						logger->warn("Reached max attempts (%d) in RTT guessing, skipping", rttMaxAttempts);
-						status.offset_rtt = status.offset_rtt_var = 0;
-						status.state = GUESS_STATE_READY;
-						break;
-					}
-					rttCurrentReps = 0;
-				}
-				status.offset_rtt++;
-				status.offset_rtt_var = status.offset_rtt + sizeof(status.rtt);
-				status.rtt = expected.rtt;
-				status.rtt_var = expected.rtt_var;
-				status.state = GUESS_STATE_CHECKING;
+			if (!guessRTT(rttCurrentAttempts, rttCurrentReps)) {
+				return false;
 			}
 			break;
 		default:
@@ -287,16 +169,156 @@ bool guess(int status_fd) {
 		if (status.state == GUESS_STATE_READY) {
 			break;
 		}
-		if (status.offset_saddr >= thresholdInetSock || status.offset_daddr >= thresholdInetSock || status.offset_sport >= thresholdInetSock ||
-			status.offset_dport >= thresholdInetSock || status.offset_netns >= thresholdInetSock || status.offset_family >= thresholdInetSock ||
-			status.offset_daddr_ipv6 >= thresholdInetSock || status.offset_segs_in >= thresholdTcpSock || status.offset_segs_out >= thresholdTcpSock ||
-			status.offset_rtt >= thresholdTcpSock || status.offset_rtt_var >= thresholdTcpSock
-		) {
+		if (overflowOccurred()) {
 			logger->error("overflow while guessing {:d}, bailing out", status.what);
-			return false;
+			return true;
 		}
 	}
 	return true;
+}
+
+template<typename T>
+void OffsetGuessing::guessSimpleField(T& statusValue, const T& expectedValue, uint16_t& offset, guess_status_t& status, const std::string& fieldStr, const guess_field& next) {
+	if (statusValue == expectedValue) {
+		logger->debug("{} offset: {:#010x}", fieldStr, offset);
+		status.what = next;
+	}
+	else {
+		++offset;
+		statusValue = expectedValue;
+	}
+	status.state = GUESS_STATE_CHECKING;
+}
+
+void OffsetGuessing::guessNetns() {
+	if (status.netns == expected.netns) {
+		logger->debug("Network namespace offset: {:#010x}", status.offset_netns);
+		status.what = GUESS_FIELD_DADDR_IPV6;
+	} else {
+		status.offset_ino++;
+		if (status.err != 0 || status.offset_ino >= thresholdInetSock) {
+			status.offset_ino = 0;
+			status.offset_netns++;
+		}
+	}
+	status.state = GUESS_STATE_CHECKING;
+}
+
+void OffsetGuessing::guessDAddrIPv6() {
+	auto ipv6_equal = [](uint32_t a[4], uint32_t b[4])->bool {
+		for (int i = 0; i < 4; ++i) {
+			if (a[i] != b[i]) {
+				return false;
+			}
+		}
+		return true;
+	};
+	if (ipv6_equal(status.daddr_ipv6, expected.daddr6)) {
+		logger->debug("IPv6 daddress offset: {:#010x}", status.offset_daddr_ipv6);
+		status.what = GUESS_FIELD_SEGS_IN;
+		// values specified below are placed somewhere below this value (actually, below inet_sock), so let's initialize their offsets
+		status.offset_segs_in = status.offset_segs_out = status.offset_rtt = status.offset_rtt_var = status.offset_daddr_ipv6 + sizeof(status.daddr_ipv6);
+	} else {
+		memcpy(&(status.daddr_ipv6), &(expected.daddr6), sizeof(expected.daddr6));
+		logger->trace("Check IPv6 daddress offset: {:#010x}", status.offset_daddr_ipv6);
+		status.offset_daddr_ipv6++;
+	}
+	status.state = GUESS_STATE_CHECKING;
+}
+
+bool OffsetGuessing::guessRTT(unsigned& currentAttempts, unsigned& currentReps) {
+	const unsigned maxAttempts = 10; // that many offsets may be verified
+	const unsigned requiredReps = 3; // value at an offset must match with the expected value at least that many times in a row
+
+	if (status.rtt == expected.rtt && status.rtt_var == expected.rtt_var) {
+		if (++currentReps == requiredReps) {
+			logger->debug("RTT offset: {:#010x}", status.offset_rtt);
+			logger->debug("RTT var offset: {:#010x}", status.offset_rtt_var);
+			status.state = GUESS_STATE_READY;
+		} else {
+			// reload expected RTT
+			if (!localsock->stopClient() || !localsock->startClient()) {
+				logger->error("Couldn't restart client for RTT guessing");
+				return false;
+			}
+			try {
+				auto expectedOpt{getExpectedValues()};
+				if (!expectedOpt) {
+					return false;
+				}
+				expected = *expectedOpt;
+			}
+			catch (const std::runtime_error& ex) {
+				logger->error(ex.what());
+				return false;
+			}
+			status.rtt = expected.rtt;
+			status.rtt_var = expected.rtt_var;
+			status.state = GUESS_STATE_CHECKING;
+		}
+	} else {
+		if (currentReps > 0) {
+			logger->debug("Skipping offset {:#010x}; RTT, RTT var values don't match anymore - found: {:d}, {:d}, expected: {:d}, {:d}",
+			status.offset_rtt, status.rtt, status.rtt_var, expected.rtt, expected.rtt_var);
+			if (++currentAttempts == maxAttempts) {
+				logger->warn("Reached max attempts={:d} in RTT guessing, skipping", maxAttempts);
+				status.offset_rtt = status.offset_rtt_var = 0;
+				status.state = GUESS_STATE_READY;
+				return true;
+			}
+			currentReps = 0;
+		}
+		status.offset_rtt++;
+		status.offset_rtt_var = status.offset_rtt + sizeof(status.rtt);
+		status.rtt = expected.rtt;
+		status.rtt_var = expected.rtt_var;
+		status.state = GUESS_STATE_CHECKING;
+	}
+	return true;
+}
+
+bool OffsetGuessing::overflowOccurred() const {
+	return status.offset_saddr >= thresholdInetSock || status.offset_daddr >= thresholdInetSock || status.offset_sport >= thresholdInetSock ||
+		status.offset_dport >= thresholdInetSock || status.offset_netns >= thresholdInetSock || status.offset_family >= thresholdInetSock ||
+		status.offset_daddr_ipv6 >= thresholdInetSock || status.offset_segs_in >= thresholdTcpSock || status.offset_segs_out >= thresholdTcpSock ||
+		status.offset_rtt >= thresholdTcpSock || status.offset_rtt_var >= thresholdTcpSock;
+}
+
+std::optional<field_values> OffsetGuessing::getExpectedValues() {
+	field_values expected;
+	expected.saddr = 0x0100007F;                   // 127.0.0.1
+	expected.daddr = 0x0200007F;                   // 127.0.0.2
+	expected.dport = htons(localsock->getServerPort());
+	expected.sport = htons(localsock->getClientPort());
+	expected.netns = own_net_ns();
+	client6.getDAddress(expected.daddr6);
+	expected.family = AF_INET;
+	expected.rtt = 0;
+	expected.rtt_var = 0;
+
+	const unsigned maxAttempts{10};
+	const auto interval{std::chrono::milliseconds(100)};
+	const unsigned requiredReps{2};
+	unsigned currentReps{0};
+
+	for (unsigned i = 0; i <= maxAttempts; ++i) {
+		auto ti{localsock->getTCPInfo()};
+		if (std::tie(expected.rtt, expected.rtt_var) == std::tie(ti.tcpi_rtt, ti.tcpi_rttvar)) {
+			if (++currentReps == requiredReps) {
+				expected.segs_in = ti.tcpi_segs_in;
+				expected.segs_out = ti.tcpi_segs_out;
+				return {expected};
+			}
+		}
+		else {
+			expected.rtt = ti.tcpi_rtt;
+			expected.rtt_var = ti.tcpi_rttvar;
+			currentReps = 1;
+		}
+		std::this_thread::sleep_for(interval);
+	}
+	LOG_WARN("Failed to stabilize expected values");
+	return std::nullopt;
 }
 
 namespace detail {
@@ -326,41 +348,11 @@ std::unique_ptr<LocalSock> startLocalSock() {
 	return localsock;
 }
 
-std::optional<field_values> getExpectedValues(LocalSock& localsock, const ClientSock6& clientsock6) {
-	field_values expected;
-	expected.saddr = 0x0100007F;                   // 127.0.0.1
-	expected.daddr = 0x0200007F;                   // 127.0.0.2
-	expected.dport = htons(localsock.getServerPort());
-	expected.sport = htons(localsock.getClientPort());
-	expected.netns = own_net_ns();
-	clientsock6.getDAddress(expected.daddr6);
-	expected.family = AF_INET;
-	expected.rtt = 0;
-	expected.rtt_var = 0;
-
-	const unsigned maxAttempts{10};
-	const auto interval{std::chrono::milliseconds(100)};
-	const unsigned requiredReps{2};
-	unsigned currentReps{0};
-
-	for (unsigned i = 0; i <= maxAttempts; ++i) {
-		auto ti{localsock.getTCPInfo()};
-		if (std::tie(expected.rtt, expected.rtt_var) == std::tie(ti.tcpi_rtt, ti.tcpi_rttvar)) {
-			if (++currentReps == requiredReps) {
-				expected.segs_in = ti.tcpi_segs_in;
-				expected.segs_out = ti.tcpi_segs_out;
-				return {expected};
-			}
-		}
-		else {
-			expected.rtt = ti.tcpi_rtt;
-			expected.rtt_var = ti.tcpi_rttvar;
-			currentReps = 1;
-		}
-		std::this_thread::sleep_for(interval);
-	}
-	LOG_WARN("Failed to stabilize expected values");
-	return std::nullopt;
+ClientSock6 prepareClient6() {
+	ClientSock6 client6;
+	client6.readLocalInterface();
+	client6.setRemoteServerAndPort();
+	return client6;
 }
 
 }

--- a/libnettracer/src/cpp/offsetguess.h
+++ b/libnettracer/src/cpp/offsetguess.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <sys/types.h>
 
@@ -24,6 +25,8 @@ class ClientSock6;
 bool guess(int status_fd);
 
 namespace detail {
+
+std::unique_ptr<LocalSock> startLocalSock();
 
 std::optional<field_values> getExpectedValues(LocalSock& localsock, const ClientSock6& clientsock6);
 

--- a/libnettracer/src/cpp/offsetguess.h
+++ b/libnettracer/src/cpp/offsetguess.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "bpf_program/nettracer-bpf.h"
+#include "localsock.h"
+#include "localsock6.h"
+#include <spdlog/fwd.h>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -19,15 +23,30 @@ struct field_values {
 	uint32_t rtt_var;
 };
 
-class LocalSock;
-class ClientSock6;
+class OffsetGuessing {
+public:
+	bool guess(int status_fd);
 
-bool guess(int status_fd);
+private:
+	bool makeGuessingAttempt(int status_fd);
+	std::optional<field_values> getExpectedValues();
+	template<typename T>
+	void guessSimpleField(T& statusValue, const T& expectedValue, uint16_t& offset, guess_status_t& status, const std::string& fieldStr, const guess_field& next);
+	void guessNetns();
+	void guessDAddrIPv6();
+	bool guessRTT(unsigned& currentAttempts, unsigned& currentReps);
+	bool overflowOccurred() const;
+
+	std::shared_ptr<spdlog::logger> logger;
+	std::unique_ptr<LocalSock> localsock;
+	ClientSock6 client6;
+	guess_status_t status;
+	field_values expected;
+};
 
 namespace detail {
 
 std::unique_ptr<LocalSock> startLocalSock();
-
-std::optional<field_values> getExpectedValues(LocalSock& localsock, const ClientSock6& clientsock6);
+ClientSock6 prepareClient6();
 
 }

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
 		return 1;
 	}
 
-	if (!guess(status_fd)) {
+	if (!OffsetGuessing{}.guess(status_fd)) {
 		LOG_ERROR("Offset guessing failed");
 		return 1;
 	}

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -168,7 +168,10 @@ int main(int argc, char* argv[]) {
 		return 1;
 	}
 
-	guess(status_fd);
+	if (!guess(status_fd)) {
+		LOG_ERROR("Offset guessing failed");
+		return 1;
+	}
 
 	netstat::NetStat netst{exitCtrl, vm.count("incremental"), vm.count("header")};
 	netst.init();


### PR DESCRIPTION
This pull request mostly aims to improve offset guessing error handling in NetTracer, making it retry connections and guessing a few times on failure. This way, it is less dependent on the environment in making another attempt. Previously, when, for example, connect failed or one of the offsets wasn't guessed correctly, whole NetTracer crashed. Handling connection and guessing errors inside NetTracer also allows more granular restarts, restarting only what is necessary. Furthermore, the introduced port randomization allows NetTracer to run on a different port in case the default one is already used.

Additionally, some refactoring was done to make offsetguess.cpp easier to read. I'd recommend going through the pull request commit by commit.