### PR TITLE
APM-286586: Improve kernel headers directory selection for building bpf_program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,45 @@ else()
 	message(FATAL_ERROR "Architecture not supported!")
 endif()
 
-set(KERNEL_HEADERS "/lib/modules/${KERNEL_VERSION}/build")
+# we need to detect locations of kernel headers
+# first, we define base directories:
+# - the one related to the current version & arch
+# - and possibly another one for generic headers
+function(try_adding_kernel_headers_base_dir out_dirs suffix)
+	string(REGEX REPLACE "-[^-]+$" "-${suffix}" MOD_KERNEL_VERSION "${KERNEL_VERSION}")
+	if(NOT MOD_KERNEL_VERSION STREQUAL KERNEL_VERSION)
+		set(DIR "/usr/src/linux-headers-${MOD_KERNEL_VERSION}")
+		if(EXISTS "${DIR}")
+			set(${out_dirs} "${${out_dirs}};${DIR}" PARENT_SCOPE)
+		endif()
+	endif()
+endfunction()
+set(KERNEL_HEADERS_BASE "/usr/src/linux-headers-${KERNEL_VERSION}")
+try_adding_kernel_headers_base_dir(KERNEL_HEADERS_BASE "common")
+# then we add various potential suffixes to the base directories and obtain actual directories to include
+function(collect_kernel_headers_dirs base_dirs out_dirs)
+	set(SUBDIRS "\
+include;\
+include/uapi;\
+include/generated;\
+include/generated/uapi;\
+arch/${ARCH}/include;\
+arch/${ARCH}/include/uapi;\
+arch/${ARCH}/include/generated;\
+arch/${ARCH}/include/generated/uapi")
+	set(COMBINED "")
+	foreach(base_dir ${base_dirs})
+		foreach(subdir ${SUBDIRS})
+			set(DIR "${base_dir}/${subdir}")
+			if(EXISTS "${DIR}")
+				list(APPEND COMBINED "${DIR}")
+			endif()
+		endforeach()
+	endforeach()
+	set(${out_dirs} "${COMBINED}" PARENT_SCOPE)
+endfunction()
+collect_kernel_headers_dirs("${KERNEL_HEADERS_BASE}" KERNEL_HEADERS)
+
 set(GCC_HEADERS "/usr/lib/gcc/${ARCHITECTURE}-linux-gnu/${GCC_VERSION}/include")
 
 # Must add include paths here because includes are applied before flags in CMake and -nostdinc messes things up

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apt update -y && \
 	# for preparing dependencies
 	git libelf-dev libboost-program-options-dev \
 	make gcc-8 g++-8 linux-headers-$KERNEL_VERSION cmake && \
-	# update links to use version 8.x of gcc/g++ and fix missing c++ link (due to not installed g++-7)
-	update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 && \
+	# update links to use version 8.x of gcc/g++
 	update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 100 --slave /usr/bin/c++ c++ /usr/bin/g++
 RUN wget --timeout=10 --tries=3 -O - https://apt.llvm.org/llvm.sh | bash -s - 10

--- a/bpf_generic/bpf_loading.cpp
+++ b/bpf_generic/bpf_loading.cpp
@@ -182,7 +182,7 @@ void bpf_subsystem::load_and_attach(kprobe& probe, const char* license, int kern
 	int insns_cnt = probe.size / sizeof(bpf_insn);
 	probe.fd = bpf::loadProgram(BPF_PROG_TYPE_KPROBE, probe.insn, insns_cnt, license, debug_print, kernVersion, sysCallBPF);
 	if (probe.fd < 0) {
-		throw std::runtime_error{fmt::format("loadProgram() failed with err={:d} ({}), logs: {}", errno, strerror(errno), getLogBuffer())};
+		throw std::runtime_error{fmt::format("loadProgram() failed for {} with err={:d} ({}), logs: {}", probe.fname, errno, strerror(errno), getLogBuffer())};
 	}
 
 	std::string name_prefix;

--- a/bpf_program/CMakeLists.txt
+++ b/bpf_program/CMakeLists.txt
@@ -11,6 +11,11 @@ else()
 	set(BPF_OPTIMIZATION "-O2")
 endif()
 
+set(ISYSTEM_KERNEL_HEADERS "")
+foreach(dir ${KERNEL_HEADERS})
+	list(APPEND ISYSTEM_KERNEL_HEADERS "-isystem" "${dir}")
+endforeach()
+
 set(CLANG_COMMAND clang
 	-D__KERNEL__ -D__TARGET_ARCH_${ARCH}
 	-D${BUILD_TYPE_MACRO}
@@ -21,13 +26,7 @@ set(CLANG_COMMAND clang
 	-nostdinc
 	-I "${CMAKE_CURRENT_LIST_DIR}"
 	-isystem ${GCC_HEADERS}
-	-isystem ${KERNEL_HEADERS}/include
-	-isystem ${KERNEL_HEADERS}/include/uapi
-	-isystem ${KERNEL_HEADERS}/include/generated/uapi
-	-isystem ${KERNEL_HEADERS}/arch/${ARCH}/include
-	-isystem ${KERNEL_HEADERS}/arch/${ARCH}/include/uapi
-	-isystem ${KERNEL_HEADERS}/arch/${ARCH}/include/generated
-	-isystem ${KERNEL_HEADERS}/arch/${ARCH}/include/generated/uapi
+	${ISYSTEM_KERNEL_HEADERS}
 	-o nettracer-bpf.c.o
 )
 


### PR DESCRIPTION
Previously, compiler had /lib/modules/... with its subdirectories as the location of the kernel headers. However, this directory doesn't seem right, especially on non-Ubuntu distributions. A better place to look at is /usr/src/.... Furthermore, in some cases, like on Debian 10 amd64, not one but two directories contain the required headers (on Debian 10 amd64 one is related to amd64-specific definitions, while the other, common, is for generic definitions).

This pull request introduces kernel headers directory seeking logic to deal with the presented issues and allow NetTracer builds e.g. on Debian. Additionally, the error message for bpf_load_program is enriched with the name of the probe whose loading failed.