### PR TITLE
APM-328142: Fix incorrect netns and IPv6 address

### DIFF
--- a/libnettracer/src/cpp/offsetguess.cpp
+++ b/libnettracer/src/cpp/offsetguess.cpp
@@ -81,7 +81,6 @@ bool OffsetGuessing::makeGuessingAttempt(int status_fd) {
 	logger->debug("guess status, set state: {:d}", status.state);
 
 	// prepare values used to verify that we are at right offset
-	field_values expected;
 	try {
 		auto expectedOpt{getExpectedValues()};
 		if (!expectedOpt) {


### PR DESCRIPTION
It looks like a local variable used during offset guessing was shadowing the member variable originally intended for keeping guessing state. This resulted in netns and IPv6 address guessing functions using uninitialized guessing state variable and generating wrong offsets. Other values were not affected because the variables required for their guessing were passed by reference to the function.