### PR TITLE
Add test mode and improve error handling

### DIFF
--- a/bpf_generic/src/CMakeLists.txt
+++ b/bpf_generic/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADERS
 	bpf_loading.h
 	bpf_wrapper.h
 	elf_utils.h
+	errors.h
 	log.h
 	kernel_version.h
 	maps_loading.h

--- a/bpf_generic/src/bpf_loading.h
+++ b/bpf_generic/src/bpf_loading.h
@@ -35,7 +35,7 @@ class bpf_subsystem {
 
 public:
 	explicit bpf_subsystem(const ISystemCalls& sysCalls = SystemCalls::getInstance());
-	void load_bpf_file(const std::string& path, uint32_t map_max_entries);
+	bool load_bpf_file(const std::string& path, uint32_t map_max_entries);
 	int get_map_fd(const std::string& name);
 	map_data get_perf_map(const std::string& name);
 	void clear_all_probes();

--- a/bpf_generic/src/errors.h
+++ b/bpf_generic/src/errors.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+class InsufficientCapabilitiesError : public std::runtime_error {
+public:
+    InsufficientCapabilitiesError(const std::string& msg)
+        : std::runtime_error(msg) {}
+};

--- a/bpf_generic/src/log.cpp
+++ b/bpf_generic/src/log.cpp
@@ -11,15 +11,15 @@ namespace logging {
 constexpr std::size_t max_size = 10 * 1024 * 1024;
 constexpr std::size_t max_files = 3;
 
-void setUpLogger(const std::string& logDir, bool standardout) {
+void setUpLogger(const std::string& logDir, bool logToStdout, bool logToFile) {
 	namespace fs = std::filesystem;
 
 	std::vector<spdlog::sink_ptr> sinks;
-	if(standardout){
+	if (logToStdout){
 		sinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
 	}
 
-	if (!logDir.empty()) {
+	if (logToFile && !logDir.empty()) {
 		fs::path logPath;
 		if (!fs::is_directory(logDir)) {
 			spdlog::warn("{} doesn't exist or is not a directory.", logDir);

--- a/bpf_generic/src/log.h
+++ b/bpf_generic/src/log.h
@@ -13,7 +13,7 @@ inline std::shared_ptr<spdlog::logger> getLogger() {
 	return spdlog::get(LOGGER_NAME);
 }
 
-void setUpLogger(const std::string& logDir, bool standardout);
+void setUpLogger(const std::string& logDir, bool logToStdout, bool logToFile);
 
 } // namespace logging
 

--- a/bpf_generic/src/maps_loading.h
+++ b/bpf_generic/src/maps_loading.h
@@ -35,7 +35,7 @@ struct map_data {
 
 using maps_config = std::vector<map_data>;
 
-void loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper);
+bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper);
 
 class MapsSectionLoader {
 public:

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -49,12 +49,21 @@ void setUpExitBehavior() {
 
 po::variables_map parseOptions(int argc, char* argv[]) {
 	po::options_description desc{"Options"};
-	desc.add_options()("help,h", "Help screen")("clear_probes,c", "Clear all probes")("debug,d", "Debug logs")(
-			"no_stdout_log,n", "Log only to file")("time_interval,t", po::value<unsigned>()->default_value(30), "Time interval")(
-			"log,l", po::value<std::string>()->default_value("./log"), "Logger path")("incremental,i", "Incremental data")(
-			"program,p", po::value<std::string>()->default_value("nettracer-bpf.o"), "BPF program path")("header,s", "Add header size")(
-			"test", "Check if NetTracer can start properly and exit")("version,v", "")("map_size,m",
-			po::value<uint32_t>()->default_value(4096), "Number of entries BPF maps");
+	// clang-format off
+	desc.add_options()
+			("clear_probes,c", "Clear all probes on start")
+			("debug,d", "Enable debug logs")
+			("no_stdout_log,n", "Disable logging to stdout, print metrics data in tabular format")
+			("log,l", po::value<std::string>()->default_value("./log"), "Logger path")
+			("time_interval,t", po::value<unsigned>()->default_value(30), "Time interval of printing metrics data")
+			("incremental,i", "Enable incremental data")
+			("program,p", po::value<std::string>()->default_value("nettracer-bpf.o"), "BPF program path")
+			("header,s", "Add average header size to traffic")
+			("map_size,m", po::value<uint32_t>()->default_value(4096), "Number of entries in BPF maps")
+			("test", "Check if NetTracer can start properly, then exit")
+			("version,v", "Print version")
+			("help,h", "Print this help screen");
+	// clang-format on
 	po::variables_map vm;
 	try {
 		po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -2,12 +2,12 @@
 #include "bpf_generic/src/bpf_wrapper.h"
 #include "bpf_generic/src/errors.h"
 #include "bpf_generic/src/log.h"
-#include "bpf_events.h"
 
-#include "proc_tcp.h"
+#include "bpf_events.h"
 #include "connections_printing.h"
 #include "netstat.h"
 #include "offsetguess.h"
+#include "proc_tcp.h"
 #include "tuple_utils.h"
 #include "unified_log.h"
 

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -54,6 +54,7 @@ po::variables_map parseOptions(int argc, char* argv[]) {
 			("clear_probes,c", "Clear all probes on start")
 			("debug,d", "Enable debug logs")
 			("no_stdout_log,n", "Disable logging to stdout, print metrics data in tabular format")
+			("no_file_log", "Disable logging to a file")
 			("log,l", po::value<std::string>()->default_value("./log"), "Logger path")
 			("time_interval,t", po::value<unsigned>()->default_value(30), "Time interval of printing metrics data")
 			("incremental,i", "Enable incremental data")

--- a/nettracersrv/unified_log.cpp
+++ b/nettracersrv/unified_log.cpp
@@ -4,16 +4,16 @@
 
 bool setUpLogging(const boost::program_options::variables_map& vm) {
 	std::string logger_path = vm["log"].as<std::string>();
-	bool stdoutlog = vm.count("no_stdout_log"); // TODO improve wording
+	bool noStdoutLog = vm.count("no_stdout_log");
 
 	std::filesystem::create_directory(logger_path);
-	logging::setUpLogger(logger_path, !stdoutlog);
+	logging::setUpLogger(logger_path, !noStdoutLog);
 
 	if (areDebugLogsEnabled(vm)) {
 		logging::getLogger()->set_level(spdlog::level::debug);
 	}
 
-	return stdoutlog;
+	return noStdoutLog;
 }
 
 spdlog::level::level_enum bpfLogLevelToSpdlogLevel(const bpf_log_level& level) {

--- a/nettracersrv/unified_log.cpp
+++ b/nettracersrv/unified_log.cpp
@@ -1,13 +1,17 @@
 #include "unified_log.h"
 #include <filesystem>
 #include <string>
+#include <utility>
 
 bool setUpLogging(const boost::program_options::variables_map& vm) {
 	std::string logger_path = vm["log"].as<std::string>();
 	bool noStdoutLog = vm.count("no_stdout_log");
+	bool noFileLog = vm.count("no_file_log");
 
-	std::filesystem::create_directory(logger_path);
-	logging::setUpLogger(logger_path, !noStdoutLog);
+	if (!noFileLog) {
+		std::filesystem::create_directory(logger_path);
+	}
+	logging::setUpLogger(logger_path, !noStdoutLog, !noFileLog);
 
 	if (areDebugLogsEnabled(vm)) {
 		logging::getLogger()->set_level(spdlog::level::debug);

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.1.3
+version=1.1.4


### PR DESCRIPTION
I've added a test mode that basically makes NetTracer only perform initial setup without further monitoring network so that it can be easily used to verify if NetTracer can start correctly. I've also added a new command line option to disable logging to files and overhauled the way errors are handled, by checking in more places for errors, improving messages, adding a specialized exception and returning more than 0/1 return codes from main.