### PR TITLE
Nonblocking write to pipe

### DIFF
--- a/libnettracer/src/connections_printing.h
+++ b/libnettracer/src/connections_printing.h
@@ -20,6 +20,7 @@
 #include "bpf_generic/src/log.h"
 #include "tuple_utils.h"
 #include "proc_tcp.h"
+#include <chrono>
 #include <unordered_set>
 #include <tuple>
 #include <condition_variable>
@@ -47,7 +48,7 @@ struct ExitCtrl {
 	bool running{true};
 	std::mutex m;
 	std::condition_variable cv;
-	unsigned wait_time;
+	std::chrono::seconds mainLoopTime;
 };
 
 template<typename Tuple>

--- a/libnettracer/src/netstat.cpp
+++ b/libnettracer/src/netstat.cpp
@@ -22,12 +22,15 @@
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 namespace netstat {
 
 constexpr auto INACTIVE_TIMEOUT = minutes(1);
 constexpr unsigned INTERVAL_DIVIDER = 10;
 constexpr int MIN_FIELD_WIDTH = 22;
+constexpr auto PIPE_SIZE = 1024 * 1024;
+constexpr auto WRITE_BACKOFF_TIME = 50ms;
 
 template <class IPTYPE>
 constexpr uint64_t addAvgHeaderSize(uint64_t pkts, bool count) {
@@ -106,8 +109,8 @@ struct TimeGuard {
 	unsigned long counter{};
 	unsigned ticks_per_wait_time;
 
-	TimeGuard(unsigned time){
-		counter = ticks_per_wait_time = time * INTERVAL_DIVIDER;
+	explicit TimeGuard(std::chrono::seconds time){
+		counter = ticks_per_wait_time = time.count() * INTERVAL_DIVIDER;
 	}
 
 	bool time_elapsed() {
@@ -141,7 +144,8 @@ std::pair<unsigned, unsigned> NetStat::countTcpSessions() {
 bool NetStat::map_loop(const bpf_fds& fdsIPv4, const bpf_fds& fdsIPv6) {
 	using namespace std::literals::chrono_literals;
 
-	TimeGuard outputCtr(exitCtrl.wait_time), logCtr(seconds(5min).count());
+	TimeGuard outputCtr(exitCtrl.mainLoopTime);
+	TimeGuard logCtr(seconds(5min));
 	printHeader();
 
 	while (exitCtrl.running && !config_changed) {
@@ -157,16 +161,17 @@ bool NetStat::map_loop(const bpf_fds& fdsIPv4, const bpf_fds& fdsIPv6) {
 			if (interactive) {
 				print_human_readable<ipv4_tuple_t>();
 				print_human_readable<ipv6_tuple_t>();
-				std::cout << tcpSessionsStr;
+				std::cout << tcpSessionsStr << std::endl;
 			} else {
-				print<ipv4_tuple_t>();
-				print<ipv6_tuple_t>();
+				std::chrono::milliseconds writeDurationLimit = std::chrono::duration_cast<std::chrono::milliseconds>(exitCtrl.mainLoopTime);
+				print<ipv4_tuple_t>(writeDurationLimit);
+				print<ipv6_tuple_t>(writeDurationLimit);
 				if (logCtr.time_elapsed()) {
 					LOG_INFO(tcpSessionsStr);
 				}
 			}
+			logging::getLogger()->flush();
 			outputCtr.reset();
-			flush();
 			clean<ipv4_tuple_t>();
 			clean<ipv6_tuple_t>();
 		}
@@ -267,19 +272,35 @@ static uint64_t subtract(uint64_t& a, uint64_t& b, int pos, bool incremental) {
 	return result;
 }
 
-void NetStat::flush() {
-	*os << " " << std::endl;
-	logging::getLogger()->flush();
+static bool writeLine(const char *buf, size_t count, std::chrono::milliseconds& writeDurationLimit) {
+    size_t total_written = 0;
+    const char *ptr = buf;
+
+    while (total_written < count && writeDurationLimit > 0s) {
+        ssize_t n = write(STDOUT_FILENO, ptr + total_written, count - total_written);
+        if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+				std::this_thread::sleep_for(WRITE_BACKOFF_TIME);
+				writeDurationLimit -= WRITE_BACKOFF_TIME;
+                continue;
+            }
+			LOG_INFO("pipe write error: {}", errno);
+            return false;
+        }
+
+        total_written += n;
+    }
+    return writeDurationLimit > 0s ? true : false;
 }
 
 template<typename IPTYPE>
-void NetStat::print() {
+void NetStat::print(std::chrono::milliseconds& writeDurationLimit) {
+	int linesSkipped = 0;
 	std::unique_lock<std::mutex> l(mx);
 	auto& aggr{connections<IPTYPE>()};
 	std::stringstream buf;
 
 	for (auto it = aggr.begin(); it != aggr.end(); ++it) {
-
 		buf.str("");
 		auto wall_now = getCurrentTimeFromSystemClock();
 		uint64_t pkts_sent = subtract(it->second.pkts_sent, it->second.pkts_sent_prev, 2, incremental);
@@ -304,8 +325,18 @@ void NetStat::print() {
 			buf << std::setw(16) << duration_cast<seconds>(it->second.start.time_since_epoch()).count() << std::setw(9)
 					  << duration.count();
 		}
-		*os << buf.str() << std::endl;
-		LOG_DEBUG(buf.str());
+
+		buf << "\n";
+		const auto strf = buf.str();
+		if (!writeLine(strf.c_str(), strf.size(), writeDurationLimit)) {
+			linesSkipped++;
+		}
+
+		LOG_DEBUG(strf);
+	}
+
+	if (linesSkipped > 0) {
+		LOG_INFO("Number of skipped lines {}", linesSkipped);
 	}
 }
 
@@ -357,6 +388,17 @@ void NetStat::init() {
 	static bpf::BPFMapsWrapper wrapper;
 	mapsWrapper = &wrapper;
 
+	if (isatty(STDOUT_FILENO)) {
+		return;
+	}
+	if (fcntl(STDOUT_FILENO, F_SETFL, O_NONBLOCK) < 0) {
+		LOG_INFO("Cannot set stdout nonblock");
+	}
+	if (fcntl(STDOUT_FILENO, F_SETPIPE_SZ, PIPE_SIZE) < 0) {
+		LOG_INFO("Cannot set pipe size");
+	}
+	int size = fcntl(STDOUT_FILENO, F_GETPIPE_SZ);
+	LOG_INFO("Pipe: size {}", size);
 }
 
 system_clock::time_point NetStat::getCurrentTimeFromSystemClock() const {

--- a/libnettracer/src/netstat.cpp
+++ b/libnettracer/src/netstat.cpp
@@ -284,7 +284,11 @@ static bool writeLine(const char *buf, size_t count, std::chrono::milliseconds& 
 				writeDurationLimit -= WRITE_BACKOFF_TIME;
                 continue;
             }
-			LOG_INFO("pipe write error: {}", errno);
+			LOG_WARN("pipe write error: {}", errno);
+			if(errno == EPIPE){
+				LOG_WARN("exiting");
+				exit(1);
+			}
             return false;
         }
 
@@ -299,9 +303,14 @@ void NetStat::print(std::chrono::milliseconds& writeDurationLimit) {
 	std::unique_lock<std::mutex> l(mx);
 	auto& aggr{connections<IPTYPE>()};
 	std::stringstream buf;
+	static bool startWithNewLine{false};
 
 	for (auto it = aggr.begin(); it != aggr.end(); ++it) {
 		buf.str("");
+		if(startWithNewLine){
+			buf << "\n";
+			startWithNewLine = false;
+		}
 		auto wall_now = getCurrentTimeFromSystemClock();
 		uint64_t pkts_sent = subtract(it->second.pkts_sent, it->second.pkts_sent_prev, 2, incremental);
 		uint64_t pkts_received = subtract(it->second.pkts_received, it->second.pkts_received_prev, 3, incremental);
@@ -330,6 +339,7 @@ void NetStat::print(std::chrono::milliseconds& writeDurationLimit) {
 		const auto strf = buf.str();
 		if (!writeLine(strf.c_str(), strf.size(), writeDurationLimit)) {
 			linesSkipped++;
+			startWithNewLine = true;
 		}
 
 		LOG_DEBUG(strf);

--- a/libnettracer/src/netstat.h
+++ b/libnettracer/src/netstat.h
@@ -92,10 +92,9 @@ protected:
 
 	void printHeader();
 	template<typename IPTYPE>
-	void print();
+	void print(std::chrono::milliseconds& writeDurationLimit);
 	template<typename IPTYPE>
 	void print_human_readable();
-	void flush();
 	template <typename IPTYPE>
 	void clean();
 

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -74,7 +74,7 @@ po::options_description getOptionsDescription() {
 			("debug,d", po::value<std::string>()->default_value("info"), "Enable debug logs")
 			("no_stdout_log,n", "Disable logging to stdout, print metrics data in tabular format")
 			("log,l", po::value<std::string>()->default_value(""), "Logger path")
-			("time_interval,t", po::value<unsigned>()->default_value(30), "Time interval of printing metrics data")
+			("time_interval,t", po::value<unsigned>()->default_value(10), "Time interval of printing metrics data")
 			("incremental,i", "Enable incremental data")
 			("noninteractive,r", "Hex output")
 			("with_loopback,f", "With loopback")
@@ -196,7 +196,7 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 
 	unsigned time_interval = vm["time_interval"].as<unsigned>();
 	LOG_INFO("time_interval: {}", time_interval);
-	exitCtrl.wait_time = time_interval;
+	exitCtrl.mainLoopTime = std::chrono::seconds{time_interval};
 
 	bpf::bpf_subsystem ebpf;
 	bpf::BPFMapsWrapper mapsWrapper;
@@ -306,7 +306,7 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 				}
 
 				std::unique_lock<std::mutex> lk{exitCtrl.m};
-				exitCtrl.cv.wait_for(lk, std::chrono::seconds(exitCtrl.wait_time), [] { return !exitCtrl.running; });
+				exitCtrl.cv.wait_for(lk, exitCtrl.mainLoopTime, [] { return !exitCtrl.running; });
 			}
 
 			promise.set_value(exitCtrl.running);


### PR DESCRIPTION
* Changed write to pipe to nonblocking API because it can cause longer deadlocks where the reader doesn't read buffered data.
* Changed default loop time to 10sec from 30sec 