### PR TITLE
Exit bpf events loop on fd close

### DIFF
--- a/libnettracer/src/bpf_events.cpp
+++ b/libnettracer/src/bpf_events.cpp
@@ -63,6 +63,9 @@ void bpf_events::loop() {
 		}
 
 		for (auto& fd : fds) {
+			if (fd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+				exit(1);
+			}
 			if (!(fd.revents & POLLIN)) {
 				continue;
 			}


### PR DESCRIPTION
Exiting bpf events loop upon poll() returning POLLERR/POLLHUP/POLLNVAL for an fd.
This PR addresses an issue where the loop is spinning up to 100% CPU utilization.