### PR TITLE
Added means to read and patch relocations to .rodata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,15 +38,11 @@ else ()
 	)
 endif ()
 
-if(DEFINED BPF_DEBUG)
-	set(BPF_DEBUG ${BPF_DEBUG})  # suppress CMake's warning about unused variable - it IS used in bpf_program
-endif()
-
 if(NOT DEFINED KERNEL_VERSION)
 	execute_process(COMMAND uname -r OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE KERNEL_VERSION)
 endif()
 
-find_package(LLVM REQUIRED CONFIG)
+find_package(LLVM 17 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 
 if(NOT DEFINED LLVM_BINDIR)
@@ -76,6 +72,20 @@ elseif(ARCHITECTURE STREQUAL "aarch64")
 	set(ARCH "arm64")
 else()
 	message(FATAL_ERROR "Architecture not supported!")
+endif()
+
+option(LEGACY_BPF "Build offsetguessed bpf programs" ON)
+if(LEGACY_BPF)
+	add_definitions("-DUSE_RODATA=0")
+else()
+	add_definitions("-DUSE_RODATA=1")
+endif()
+
+option(BPF_DEBUG "Enable bpf_trace_printk logging" OFF)
+if(BPF_DEBUG)
+	set(BPF_DEBUG 1)
+else()
+	set(BPF_DEBUG 0)
 endif()
 
 # we need to detect locations of kernel headers

--- a/bpf_generic/src/bpf_loading.cpp
+++ b/bpf_generic/src/bpf_loading.cpp
@@ -236,7 +236,7 @@ void bpf_subsystem::load_programs_from_sections(const BpfPrograms& bpfPrograms, 
 	bool allFailed = true;
     for (const auto& [name, program]: bpfPrograms) {
 		LOG_DEBUG("loading {} {}", name, program.size());
-		kprobe probe{.fname = name, .insn = std::bit_cast<bpf_insn*>(program.data()), .size = program.size(), .fd = -1, .efd = -1};
+		kprobe probe{.fname = std::string(name), .insn = std::bit_cast<bpf_insn*>(program.data()), .size = program.size(), .fd = -1, .efd = -1};
 		allFailed &= !load_and_attach(probe, license, kernVersion);
 	}
 
@@ -257,12 +257,15 @@ bpf_subsystem::bpf_subsystem(const ISystemCalls& sysCalls)
 	: sysCalls(sysCalls) {}
 
 bool bpf_subsystem::load_bpf_file(const std::string& path, uint32_t map_max_entries) {
-
-	MapsSectionLoader sectionloader(path);
-	maps = sectionloader.load();
+	SectionLoader sectionloader(path);
+	if (!sectionloader.loadSections()) {
+		LOG_ERROR("Error loading sections from elf");
+		return false;
+	}
+	maps = sectionloader.getMapsConfig();
 	BPFMapsWrapper mapsWrapper;
 	set_maps_max_entries(map_max_entries);
-	if (!loadMaps(maps, mapsWrapper)) {
+	if (!loadMaps(maps, mapsWrapper, sectionloader.getRodataSection())) {
 		LOG_ERROR("Cannot load BPF maps");
 		return false;
 	}
@@ -272,7 +275,7 @@ bool bpf_subsystem::load_bpf_file(const std::string& path, uint32_t map_max_entr
 		return false;
 	}
 
-	if (!sectionloader.processReloSections(maps)) {
+	if (!sectionloader.relocateData(maps)) {
 		LOG_ERROR("Processing relocations failed");
 		return false;
 	}
@@ -286,7 +289,7 @@ bool bpf_subsystem::load_bpf_file(const std::string& path, uint32_t map_max_entr
 		// don't return, see what happens
 	}
 
-	load_programs_from_sections(sectionloader.getBpfPrograms(), *kernelVersion, sectionloader.getLicense().c_str());
+	load_programs_from_sections(sectionloader.getBpfPrograms(), *kernelVersion, sectionloader.getLicense());
 	return true;
 }
 

--- a/bpf_generic/src/bpf_loading.h
+++ b/bpf_generic/src/bpf_loading.h
@@ -32,6 +32,8 @@ namespace bpf {
 struct map_data;
 using maps_config = std::vector<map_data>;
 
+using BpfPrograms = std::unordered_map<std::string_view, std::vector<char>>;
+
 struct kprobe {
 	std::string fname;
 	bpf_insn* insn;
@@ -47,7 +49,7 @@ class bpf_subsystem {
 	const ISystemCalls& sysCalls;
 
 	bool load_and_attach(kprobe& prgrm, const char* license, int kernVersion);
-	void load_programs_from_sections(const std::unordered_map<std::string, llvm::StringRef>& bpfPrograms, int kernVersion, const char* license);
+	void load_programs_from_sections(const BpfPrograms& bpfPrograms, int kernVersion, const char* license);
 	int install_kprobe_fs(const std::string& prefix, const std::string& name, bool is_kprobe, int fd);
 	int uninstall_kprobe_fs(const std::string& cmd);
 	void close_all_probes();

--- a/bpf_generic/src/maps_loading.cpp
+++ b/bpf_generic/src/maps_loading.cpp
@@ -43,58 +43,29 @@ std::string to_string(bpf_map_type type) {
 		return "Unsupported type";
 	}
 }
+}
 
-bool readAndApplyRelocations(const llvm::object::SectionRef& sec, bpf_insn* insn, maps_config& maps) {
-	for (auto it = sec.relocation_begin(); it != sec.relocation_end(); ++it){
-		unsigned insn_idx = it->getOffset() / sizeof(bpf_insn);
-		if (insn[insn_idx].code != (BPF_LD | BPF_IMM | BPF_DW)) {
-			LOG_ERROR("Invalid relo for insn[{}], code {}", insn_idx, insn[insn_idx].code);
-			return false;
-		}
-		if (!it->getSymbol()->getAddress()){
-			continue;
-		}
-		if ( !(*it->getSymbol()->getSection())->getName()->equals("maps")){
-			LOG_ERROR("Relo symbol {} not from map section", it->getSymbol()->getName()->str());
-			return false;
-		}
+SectionLoader::SectionLoader(const std::string& path){
 
-		size_t origOffset = *it->getSymbol()->getAddress();
-		auto el = std::find_if(maps.begin(), maps.end(), [&](auto& mit) { return mit.elf_offset == origOffset; });
-		if (el != maps.end()) {
-			insn[insn_idx].src_reg = BPF_PSEUDO_MAP_FD;
-			insn[insn_idx].imm = el->fd;
-		} else {
-			LOG_ERROR("Invalid relo for insn[{:d}] - no matching map", insn_idx);
-			return false;
-		}
+	auto BufferOrErr = WriteThroughMemoryBuffer::getFile(path.c_str());
+	if (!BufferOrErr) {
+		throw std::runtime_error("Error reading file");
 	}
 
-	return true;
-}
-}
-
-MapsSectionLoader::MapsSectionLoader(const std::string& path){
-
-    auto BufferOrErr = WriteThroughMemoryBuffer::getFile(path.c_str());
-    if (!BufferOrErr) {
-        throw std::runtime_error("Error reading file");
-    }
-
 	memBufffer.swap(*BufferOrErr);
-    Expected<std::unique_ptr<Binary>> BinOrErr = createBinary(memBufffer->getMemBufferRef());
-    if (!BinOrErr) {
-        throw std::runtime_error("Error parsing ELF");
-    }
+	Expected<std::unique_ptr<Binary>> BinOrErr = createBinary(memBufffer->getMemBufferRef());
+	if (!BinOrErr) {
+		throw std::runtime_error("Error parsing ELF");
+	}
 
 	binary.swap(*BinOrErr);
-    ELFobj = dyn_cast<ELFObjectFileBase>(binary.get());
-    if (!ELFobj) {
-        throw std::runtime_error("Error ELFObj");
-    }
+	ELFobj = dyn_cast<ELFObjectFileBase>(binary.get());
+	if (!ELFobj) {
+		throw std::runtime_error("Error ELFObj");
+	}
 }
 
-bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper) {
+bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper, const llvm::object::SectionRef* rodataSec) {
 	bool all_ok = true;
 	for (auto& map : maps) {
 		int numa_node = map.def.map_flags & BPF_F_NUMA_NODE ? map.def.numa_node : -1;
@@ -112,6 +83,12 @@ bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper) {
 		}
 		map.fd = fd;
 
+		// init (memcpy) rodata
+		if (map.name == ".rodata" && rodataSec) {
+			int zero = 0;
+			all_ok = mapsWrapper.updateElement(fd, &zero, rodataSec->getContents()->data());
+		}
+
 		LOG_DEBUG("{:50} capacity={:d}, flags={:d}, kv size={:d}+{:d}",
 			fmt::format("Map for FD={:d}: {} ({})", map.fd, map.name, to_string(map.def.type)),
 			map.def.max_entries,
@@ -122,16 +99,155 @@ bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper) {
 	return all_ok;
 }
 
-maps_config MapsSectionLoader::load() {
-	auto sym{getSymTableEntriesForMaps()};
+bool SectionLoader::loadSections() {
+	// iterating over ELF sections is done by means of SectionRef::moveNext(), i.e. updating the SectionRef obj
+	// -> must create another SectionRef instance for each section being enumerated
+	for (auto& section : ELFobj->sections()) {
+		if (!section.getName()) {
+			continue;
+		}
+		std::string_view sectionName(*section.getName());
+		auto sectionContent = section.getContents();
+		if (!sectionContent) {
+			continue;
+		}
 
-	if (sym.empty()) {
-		LOG_ERROR("No maps found in sections");
-		return {};
+		if (sectionName.starts_with("kprobe") || sectionName.starts_with("kretprobe")) {
+			sections.kprobes.emplace(sectionName, llvm::object::SectionRef(section.getRawDataRefImpl(), section.getObject()));
+		} else if (sectionName.starts_with(".rel")) {
+			auto relSectionName = sectionName.substr(4);
+			if (!sections.rel.emplace(relSectionName, llvm::object::SectionRef(section.getRawDataRefImpl(), section.getObject())).second) {
+				return false;
+			}
+			for (auto& rel : section.relocations()) {
+				auto relSymbol = rel.getSymbol();
+				if (!relSymbol->getSection()) {
+					return false;
+				}
+				auto relSection = *relSymbol->getSection();
+				if (!relSection->getName()) {
+					return false;
+				}
+				auto relSectionName = relSection->getName();
+				if (!relSectionName) {
+					return false;
+				}
+				if (relSectionName->str() == "maps") {
+					auto relSymbolAddr = relSymbol->getAddress();
+					if (!relSymbolAddr) {
+						return false;
+					}
+					auto relSymbolName = relSymbol->getName();
+					if (!relSymbolName) {
+						return false;
+					}
+					mapsRelSymOffsToName.try_emplace(*relSymbolAddr, std::string_view(*relSymbolName));
+				}
+			}
+		} else if (sectionName == "maps") {
+			if (sections.maps) {
+				return false;
+			}
+			auto mapsBody = section.getContents();
+			if (!mapsBody) {
+				return false;
+			}
+			if (mapsBody->size() == 0) {
+				return false;
+			}
+			sections.maps = std::make_unique<llvm::object::SectionRef>(section.getRawDataRefImpl(), section.getObject());
+		} else if (sectionName == "license") {
+			if (sections.license) {
+				return false;
+			}
+			sections.license = std::make_unique<llvm::object::SectionRef>(section.getRawDataRefImpl(), section.getObject());
+		} else if (sectionName == ".rodata") {
+			if (sections.rodata) {
+				return false;
+			}
+			auto rodataBody = section.getContents();
+			if (!rodataBody) {
+				return false;
+			}
+			if (rodataBody->size() == 0) {
+				return false;
+			}
+			sections.rodata = std::make_unique<llvm::object::SectionRef>(section.getRawDataRefImpl(), section.getObject());
+		}
 	}
-	symbolsMap = sym;
+	return !sections.kprobes.empty() && sections.maps && !mapsRelSymOffsToName.empty() && sections.license;
+}
 
-	const std::size_t map_sz_elf = content.size() / sym.size();
+bool SectionLoader::relocateData(maps_config& maps) {
+	constexpr uint64_t R_BPF_64_64 = 1;
+#if USE_RODATA
+	auto rodataMap = std::find_if(maps.begin(), maps.end(), [](auto& map) { return map.name == ".rodata"; });
+#endif // USE_RODATA
+
+	for (auto& [kprobeName, kprobeRel] : sections.rel) {
+		auto itkprobe = sections.kprobes.find(kprobeName);
+		if (itkprobe == sections.kprobes.end()) {
+			continue;
+		}
+		auto& kprobe = itkprobe->second;
+		auto kprobeBody = *kprobe.getContents();
+
+		// must copy the bpf prog body: llvm elf structs are mmap'd directly from .o file, and patching relocs would overwrite the file
+		auto [itBody, ok] = bpfPrograms.emplace(kprobeName, std::vector<char>(kprobeBody.begin(), kprobeBody.end()));
+		auto* bytecode = std::bit_cast<bpf_insn*>(itBody->second.data());
+
+		// read and patch kprobe relocations
+		for (auto& rel : kprobeRel.relocations()) {
+			auto relOffs = rel.getOffset();
+			if (relOffs >= itBody->second.size()) {
+				LOG_ERROR("prog:{}[{}]: invalid relo offset {}", kprobeName, itBody->second.size(), relOffs);
+				return false;
+			}
+
+			auto offs = relOffs / sizeof(bpf_insn);
+			if (rel.getType() != R_BPF_64_64) {
+				LOG_ERROR("prog:{}+{}: unknown relo type:{}", kprobeName, offs, rel.getType());
+				return false;
+			}
+			if (auto opcode = bytecode[offs].code; opcode != (BPF_LD | BPF_IMM | BPF_DW)) {
+				LOG_ERROR("prog:{}+{}: unknown opcode:{} ", kprobeName, offs, opcode);
+				return false;
+			}
+
+			auto relSymbol = rel.getSymbol();
+			auto relSymbolAddr = relSymbol->getAddress();
+			if (!relSymbolAddr) {
+				LOG_ERROR("prog:{}+{}: unknown relocation addr", kprobeName, offs);
+				return false;
+			}
+
+			// (src_reg, imm) mapping ref. https://www.kernel.org/doc/html/latest/bpf/standardization/instruction-set.html#bit-immediate-instructions
+			if (sections.maps->containsSymbol(*relSymbol)) {
+				auto map = std::find_if(maps.begin(), maps.end(), [&relSymbolAddr](auto& map) { return map.elf_offset == *relSymbolAddr; });
+				if (map == maps.end()) {
+					LOG_ERROR("prog:{}+{}: unknown relocation to maps section", kprobeName, offs);
+					return false;
+				}
+				bytecode[offs].src_reg = BPF_PSEUDO_MAP_FD;
+				bytecode[offs].imm = map->fd;
+#if USE_RODATA
+			} else if (sections.rodata && sections.rodata->containsSymbol(*relSymbol) && rodataMap != maps.end()) {
+				bytecode[offs + 1].imm = bytecode[offs].imm + *relSymbolAddr;
+				bytecode[offs].src_reg = BPF_PSEUDO_MAP_VALUE;
+				bytecode[offs].imm = rodataMap->fd;
+#endif // USE_RODATA
+			} else {
+				LOG_ERROR("prog:{}+{}: invalid relocation to section:{}", kprobeName, offs, relSymbol->getName()->str());
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+maps_config SectionLoader::getMapsConfig() {
+	auto mapsBody = sections.maps->getContents();
+	const std::size_t map_sz_elf = mapsBody->size() / mapsRelSymOffsToName.size();
 	std::size_t map_sz_copy = sizeof(map_def);
 	LOG_DEBUG("map_sz_elf {} {}" , map_sz_elf, map_sz_copy);
 	if (map_sz_elf < map_sz_copy) {
@@ -139,43 +255,8 @@ maps_config MapsSectionLoader::load() {
 		map_sz_copy = map_sz_elf;
 	}
 
-	return copyElfMapsDataToMapsConfig(sym, map_sz_copy);
-}
- 
-MapsSymbols MapsSectionLoader::getSymTableEntriesForMaps() {
-	MapsSymbols symbols;
-
-    for (const SectionRef &sec : ELFobj->sections()){
-		for (auto it = sec.relocation_begin(); it != sec.relocation_end(); ++it){
-			auto ssec =  it->getSymbol()->getSection();
-			if (!ssec){
-				continue;
-			}
-			if ((*(*ssec)->getName()).str() == "maps" ){
-				symbols.try_emplace(*it->getSymbol()->getAddress(), it->getSymbol()->getName()->str());
-				content =  *(*ssec)->getContents();
-			}
-		}
-
-		if (!sec.getName()){
-			continue;
-		} else if (sec.getName()->starts_with("kprobe") || sec.getName()->starts_with("kretprobe")){
-			if (!sec.getContents()){
-				LOG_DEBUG("No bpf prog in section for: {}", sec.getName()->str());
-				continue;
-			}
-			bpfPrograms[sec.getName()->str()] = *sec.getContents();
-		} else if (sec.getName()->equals("license")){
-			license = *sec.getContents();
-		}
-    }
-	return symbols;
-}
-
-maps_config MapsSectionLoader::copyElfMapsDataToMapsConfig(const MapsSymbols& symbols, std::size_t map_sz_copy) const {
 	maps_config maps;
-	maps.reserve(symbols.size());
-	for (const auto& [offset, name] : symbols) {
+	for (const auto& [offset, name] : mapsRelSymOffsToName) {
 		map_data map;
 		map.name = name;
 		if (map.name.empty()) {
@@ -183,38 +264,35 @@ maps_config MapsSectionLoader::copyElfMapsDataToMapsConfig(const MapsSymbols& sy
 			continue;
 		}
 		// Calculate the offset where symbol is stored in maps section data area;
-		const map_def* def = std::bit_cast<const map_def*>(content.data() + offset);
+		const map_def* def = std::bit_cast<const map_def*>(mapsBody->data() + offset);
 		map.elf_offset = offset;
 		memset(&map.def, 0, sizeof(map.def));
 		memcpy(&map.def, def, map_sz_copy);
 		maps.push_back(std::move(map));
 	}
+
+#if USE_RODATA
+	// create a map for .rodata
+	if (sections.rodata) {
+		auto rodataBody = sections.rodata->getContents();
+		map_data map;
+		map.name = ".rodata";
+		map.elf_offset = 0;
+		map.def = {
+			.type = BPF_MAP_TYPE_ARRAY,
+			.key_size = sizeof(int),
+			.value_size = static_cast<uint32_t>(rodataBody->size()),
+			.max_entries = 1,
+			.map_flags = BPF_F_RDONLY_PROG | BPF_F_MMAPABLE,
+			.inner_map_idx = 0,
+			.numa_node = 0
+		};
+		map.fd = -1;
+		maps.push_back(std::move(map));
+	}
+#endif // USE_RODATA
+
 	return maps;
 }
-
-bool MapsSectionLoader::processReloSections(maps_config& maps) {
-	bool all_ok = true;
-    for (const SectionRef &sec : ELFobj->sections()) {
-		if (!sec.getName()) {
-			continue;
-		}
-		if (!sec.getName()->starts_with(".rel")) {
-			continue;
-		}
-		auto secName = sec.getName()->substr(4);
-
-		auto it = bpfPrograms.find(secName.str());
-		if( it == bpfPrograms.end()){
-			LOG_DEBUG("No program for section name {}", secName.str());
-			continue;
-		}
-
-		bpf_insn* insns = std::bit_cast<bpf_insn*>(it->second.data());
-		if (!readAndApplyRelocations(sec, insns, maps)) {
-			LOG_ERROR("Relocations for section {:d} failed", sec.getIndex());
-			all_ok = false;
-		}
-	}
-	return all_ok;
-}
+ 
 } // namespace bpf

--- a/bpf_generic/src/maps_loading.h
+++ b/bpf_generic/src/maps_loading.h
@@ -23,32 +23,38 @@
 
 #include "bpf_loading.h"
 #include "maps_def.h"
+#include <memory>
 #include <unordered_map>
 
 namespace bpf {
 
-bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper);
+bool loadMaps(maps_config& maps, BPFMapsWrapper& mapsWrapper, const llvm::object::SectionRef* rodataSec);
 
-using BpfPrograms = std::unordered_map<std::string, llvm::StringRef>;
-using MapsSymbols = std::unordered_map<size_t, std::string>;
+using MapsSymbols = std::unordered_map<uintptr_t, std::string_view>;
 
-class MapsSectionLoader {
+class SectionLoader {
 public:
-	explicit MapsSectionLoader(const std::string& path);
-	maps_config load();
-	bool processReloSections(maps_config& maps);
-	BpfPrograms& getBpfPrograms(){ return bpfPrograms;}
-	std::string getLicense(){ return license.str();}
-private:
-	MapsSymbols getSymTableEntriesForMaps();
-	maps_config copyElfMapsDataToMapsConfig(const MapsSymbols& sym, std::size_t map_sz_copy) const;
+	explicit SectionLoader(const std::string& path);
+	bool loadSections();
+	bool relocateData(maps_config& maps);
 
-	llvm::StringRef content;
-	llvm::StringRef license;
+	const llvm::object::SectionRef* getRodataSection() const { return sections.rodata.get(); }
+	maps_config getMapsConfig();
+	BpfPrograms& getBpfPrograms(){ return bpfPrograms;}
+	const char* getLicense(){ return sections.license->getContents()->data();}
+private:
+	struct {
+		std::unordered_map<std::string_view, llvm::object::SectionRef> kprobes{};
+		std::unordered_map<std::string_view, llvm::object::SectionRef> rel{};
+		std::unique_ptr<llvm::object::SectionRef> maps{};
+		std::unique_ptr<llvm::object::SectionRef> license{};
+		std::unique_ptr<llvm::object::SectionRef> rodata{};
+	} sections{};
+	MapsSymbols mapsRelSymOffsToName;
+
 	std::unique_ptr<llvm::WriteThroughMemoryBuffer> memBufffer;
 	std::unique_ptr<llvm::object::Binary> binary;
 	llvm::object::ELFObjectFileBase *ELFobj;
-	MapsSymbols symbolsMap;
 	BpfPrograms bpfPrograms;
 };
 

--- a/bpf_program/CMakeLists.txt
+++ b/bpf_program/CMakeLists.txt
@@ -16,7 +16,6 @@ set(SOURCES
 )
 
 PREPEND(SOURCES_FULL "${CMAKE_CURRENT_LIST_DIR}" ${SOURCES})
-option(LEGACY_BPF "Build offsetguessed bpf programs" ON)
 
 set(HEADERS
 	metrics_utilities.h
@@ -25,7 +24,6 @@ set(HEADERS
 	probes/metrics.h
 	tuples_utilities.h
 )
-
 
 if(LEGACY_BPF)
 	list(APPEND HEADERS
@@ -36,7 +34,7 @@ if(LEGACY_BPF)
 		legacy/other.h
 	)
 	set(CLANG_COMMAND ${LLVM_BINDIR}/clang
-		-D__KERNEL__ -D__TARGET_ARCH_${ARCH} -DLEGACY_BPF=1
+		-D__KERNEL__ -D__TARGET_ARCH_${ARCH} -DLEGACY_BPF=1 -DUSE_RODATA=0 -DBPF_DEBUG=${BPF_DEBUG}
 		-D${BUILD_TYPE_MACRO}
 		-fno-jump-tables -fno-builtin
 		-Wall -Wpadded -Werror
@@ -62,7 +60,7 @@ else()
 	)
 	set(BPF_OUTPUT_FILE "nettracer-bpf.core.o")
 	set(FULL_COMMAND ${LLVM_BINDIR}/clang
-		-D__TARGET_ARCH_${ARCH}
+		-D__TARGET_ARCH_${ARCH} -DUSE_RODATA=1 -DBPF_DEBUG=${BPF_DEBUG}
 		-fno-jump-tables -fno-builtin
 		-Wall -Werror
 		${BPF_OPTIMIZATION}

--- a/bpf_program/legacy/log.h
+++ b/bpf_program/legacy/log.h
@@ -90,17 +90,3 @@ void log_bpf(struct pt_regs *ctx, enum bpf_log_level severity, const char* fmt, 
 #define LOG_WARN_BPF(ctx, fmt, ...)     LOG_BPF(ctx, BPF_LOG_LEVEL_WARN, fmt, __VA_ARGS__)
 #define LOG_ERROR_BPF(ctx, fmt, ...)    LOG_BPF(ctx, BPF_LOG_LEVEL_ERROR, fmt, __VA_ARGS__)
 #define LOG_CRITICAL_BPF(ctx, fmt, ...) LOG_BPF(ctx, BPF_LOG_LEVEL_CRITICAL, fmt, __VA_ARGS__)
-
-// use DEBUG_BPF only for debugging purposes where using perf event-based logging is not possible
-// the messages appear in /sys/kernel/debug/tracing/trace
-// max 3 printf-style args allowed
-
-#ifdef DEBUG
-#define DEBUG_BPF(format, ...) \
-	{ \
-		char fmt[] = "[nettracer] " format "\n"; \
-		bpf_trace_printk(fmt, sizeof(fmt), ##__VA_ARGS__); \
-	}
-#else
-#define DEBUG_BPF(...)
-#endif

--- a/bpf_program/legacy/other.h
+++ b/bpf_program/legacy/other.h
@@ -20,6 +20,7 @@
 #include "maps.h"
 #include "nettracer-bpf.h"
 #include "offset_guessing.h"
+#include "print.h"
 
 #include <linux/ptrace.h>
 #include <linux/tcp.h>
@@ -38,13 +39,13 @@ int kprobe__tcp_getsockopt(struct pt_regs *ctx) {
 	uint32_t zero = 0;
 	struct guess_status_t *status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
-		DEBUG_BPF("tcp_getsockopt: guessing status is null");
+		BPF_PRINTK("tcp_getsockopt: guessing status is null");
 		return 0;
 	}
 
 	uint64_t pid = bpf_get_current_pid_tgid();
 	if (status->pid_tgid != pid) {
-		DEBUG_BPF("tcp_getsockopt: non-matching pid (%d != %d)", status->pid_tgid, pid);
+		BPF_PRINTK("tcp_getsockopt: non-matching pid (%d != %d)", status->pid_tgid, pid);
 		return 0;
 	}
 

--- a/bpf_program/print.h
+++ b/bpf_program/print.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef LEGACY_BPF
+#include "legacy/bpf_helpers.h"
+#else
+#include <bpf/bpf_helpers.h>
+#endif
+
+#if USE_RODATA
+#define BPF_PRINTK_FMT_DECLSPEC static
+#else
+#define BPF_PRINTK_FMT_DECLSPEC
+#endif
+
+#define BPF_PRINTK_ARGS(fmt, ...) \
+do { \
+	BPF_PRINTK_FMT_DECLSPEC const char format[] = fmt; \
+	bpf_trace_printk(format, sizeof(format), __VA_ARGS__); \
+} while (false)
+
+#define BPF_PRINTK_NOARGS(msg) \
+do { \
+	BPF_PRINTK_FMT_DECLSPEC const char message[] = msg; \
+	bpf_trace_printk(message, sizeof(message)); \
+} while (false)
+
+#define BPF_PRINTK_SELECT(a0, a1, a2, a3, select, ...) select
+
+// use only for debug purposes where using perf event-based logging is not possible
+// output in /sys/kernel/debug/tracing/trace
+// max 3 printf-style args allowed
+#if BPF_DEBUG
+#define BPF_PRINTK(fmt, ...) \
+	BPF_PRINTK_SELECT(a0, ##__VA_ARGS__, BPF_PRINTK_ARGS, BPF_PRINTK_ARGS, BPF_PRINTK_ARGS, BPF_PRINTK_NOARGS)(fmt, ##__VA_ARGS__)
+#else
+#define BPF_PRINTK(fmt, ...)
+#endif

--- a/bpf_program/probes/connections.h
+++ b/bpf_program/probes/connections.h
@@ -36,6 +36,8 @@
 #define LOG_DEBUG_BPF(...)
 #endif
 
+#include "print.h"
+
 #ifdef LEGACY_BPF
 SEC("kprobe/tcp_v4_connect")
 int kprobe__tcp_v4_connect( struct pt_regs *ctx) {
@@ -97,6 +99,8 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 	uint32_t cpu = bpf_get_smp_processor_id();
 	if (bpf_map_update_elem(&tuplepid_ipv4, &t, &p, BPF_ANY) < 0) {
 		LOG_DEBUG_BPF(ctx, "Connect missed, reached max conns?: {:d}:{:d} {:d}:{:d} {:d}", t.saddr, t.sport, t.daddr, t.dport, pid >> 32);
+		BPF_PRINTK("Update failed connectv4/src: %x :%d", t.saddr, t.sport);
+		BPF_PRINTK("Update failed connectv4/dst: %x :%d", t.daddr, t.dport);
 	}
 
 	struct tcp_ipv4_event_t evt = convert_ipv4_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CONNECT, pid >> 32);
@@ -164,6 +168,8 @@ int kretprobe__tcp_v6_connect(struct pt_regs *ctx)
 
 	if (bpf_map_update_elem(&tuplepid_ipv6, &t, &p, BPF_ANY) < 0) {
 		LOG_DEBUG_BPF(ctx, "Connect v6 missed, reached max conns?: {:d}{:d}:{:d} {:d}{:d}:{:d} {:d}", t.saddr_h, t.saddr_l, t.sport, t.daddr_h, t.daddr_l, t.dport, pid >> 32);
+		BPF_PRINTK("Update failed connectv6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
+		BPF_PRINTK("Update failed connectv6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 	}
 
 	struct tcp_ipv6_event_t evt = convert_ipv6_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CONNECT, pid >> 32);
@@ -205,6 +211,8 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 			struct pid_comm_t p = {.pid = pid, .state = CONN_ACTIVE};
 			if (bpf_map_update_elem(&tuplepid_ipv4, &t, &p, BPF_ANY) < 0) {
 				LOG_DEBUG_BPF(ctx, "Accept missed, reached max conns?: {:d}:{:d} {:d}:{:d} {:d}", t.saddr, t.sport, t.daddr, t.dport, pid >> 32);
+				BPF_PRINTK("Update failed acceptv4/src: %x :%d", t.saddr, t.sport);
+				BPF_PRINTK("Update failed acceptv4/dst: %x :%d", t.daddr, t.dport);
 			}
 			bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt));
 		}
@@ -234,6 +242,8 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 						t.daddr_l,
 						t.dport,
 						pid >> 32);
+				BPF_PRINTK("Update failed acceptv6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
+				BPF_PRINTK("Update failed acceptv6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 			}
 			bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt));
 		}
@@ -271,6 +281,8 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 		pp = bpf_map_lookup_elem(&tuplepid_ipv4, &t);
 		if (pp == NULL) {
 			LOG_DEBUG_BPF(ctx, "Missing tuplepid entry: {:d}:{:d} {:d}:{:d}", t.saddr, t.sport, t.daddr, t.dport);
+			BPF_PRINTK("Update failed closev4/src: %x :%d", t.saddr, t.sport);
+			BPF_PRINTK("Update failed closev4/dst: %x :%d", t.daddr, t.dport);
 		} else {
 			pp->state = CONN_CLOSED;
 		}
@@ -298,6 +310,8 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 					t.daddr_h,
 					t.daddr_l,
 					t.dport);
+			BPF_PRINTK("Update failed closev6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
+			BPF_PRINTK("Update failed closev6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 		} else {
 			pp->state = CONN_CLOSED;
 		}


### PR DESCRIPTION
Updating the BPF program loading flow:
1. loading of all ELF sections,
2. creation of bpf maps,
3. relocations patching.

For this purpose, the MapsSectionLoader is generalized and renamed to SectionLoader.
ELF section reading is now decoupled from the creation of maps_config. Separate map is created for .rodata section.
Added means to patch .rodata relocations. Relocations patching is updated to check for R_BPF_64_64 relocation type.

Added `BPF_PRINTK(fmt, ...)` helper macro for `bpf_trace_printk()`.

Additionally, fixed the following issues:
* bpf object file overwrites by relocations patching,
* build issue related to llvm-dev package version.