### PR TITLE
Debug counters bpf map added for error logging

### DIFF
--- a/bpf_generic/src/CMakeLists.txt
+++ b/bpf_generic/src/CMakeLists.txt
@@ -2,7 +2,7 @@ set(SOURCES
 	bpf_loading.cpp
 	bpf_wrapper.cpp
 	log.cpp
-	kernel_version.cpp
+	system_utils.cpp
 	maps_loading.cpp
 	perf_event.cpp
 	system_calls.cpp
@@ -13,7 +13,7 @@ set(HEADERS
 	bpf_wrapper.h
 	errors.h
 	log.h
-	kernel_version.h
+	system_utils.h
 	maps_loading.h
 	perf_event.h
 	perf_sys.h

--- a/bpf_generic/src/bpf_loading.cpp
+++ b/bpf_generic/src/bpf_loading.cpp
@@ -17,7 +17,7 @@
 
 #include "bpf_wrapper.h"
 #include "errors.h"
-#include "kernel_version.h"
+#include "system_utils.h"
 #include "maps_loading.h"
 #include "perf_sys.h"
 

--- a/bpf_generic/src/system_utils.cpp
+++ b/bpf_generic/src/system_utils.cpp
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include "kernel_version.h"
+#include "system_utils.h"
 
 #include <cerrno>
 #include <cstdio>
@@ -123,6 +123,44 @@ std::string kernelVersionToString(int kernelVersion) {
 	int minor{(kernelVersion >> 8) - (major << 8)};
 	int patch{kernelVersion - (major << 16) - (minor << 8)};
 	return std::to_string(major) + '.' + std::to_string(minor) + '.' + std::to_string(patch);
+}
+
+std::optional<unsigned> getNumPossibleCpus(const ISystemCalls& sysCalls) {
+	// /sys/devices/system/cpu/possible contains a comma-separated list of
+	// inclusive ranges describing CPU ids that the kernel may bring online,
+	// e.g. "0-3", "0,2-5,7", or a bare "0". This is the same source libbpf
+	// uses to size per-CPU map buffers (libbpf_num_possible_cpus()).
+	FileScopeGuard file{sysCalls.fopen("/sys/devices/system/cpu/possible", "r"), sysCalls};
+	if (!*file) {
+		return std::nullopt;
+	}
+	const size_t maxLength{128};
+	std::string content(maxLength, '\0');
+	const size_t bytesRead{sysCalls.fread(content.data(), maxLength, *file)};
+	if (bytesRead == 0) {
+		return std::nullopt;
+	}
+	content.resize(bytesRead);
+
+	unsigned total{0};
+	bool sawAny{false};
+	std::regex rangeRegex{R"((\d+)(?:-(\d+))?)"};
+	auto begin{std::sregex_iterator{content.cbegin(), content.cend(), rangeRegex}};
+	auto end{std::sregex_iterator{}};
+	for (auto it{begin}; it != end; ++it) {
+		const auto& match{*it};
+		unsigned first{static_cast<unsigned>(std::stoul(match.str(1)))};
+		unsigned last{match[2].matched ? static_cast<unsigned>(std::stoul(match.str(2))) : first};
+		if (last < first) {
+			return std::nullopt;
+		}
+		total += (last - first + 1);
+		sawAny = true;
+	}
+	if (!sawAny) {
+		return std::nullopt;
+	}
+	return total;
 }
 
 } // namespace bpf

--- a/bpf_generic/src/system_utils.h
+++ b/bpf_generic/src/system_utils.h
@@ -29,4 +29,10 @@ bool isKernelSupported(int kernelVersion);
 
 std::string kernelVersionToString(int kernelVersion);
 
+// Returns the number of possible CPUs reported by the kernel via
+// /sys/devices/system/cpu/possible (the same value libbpf uses for sizing
+// per-CPU BPF maps). Returns std::nullopt if the file cannot be read or
+// parsed.
+std::optional<unsigned> getNumPossibleCpus(const ISystemCalls& sysCalls);
+
 } // namespace bpf

--- a/bpf_generic/test/CMakeLists.txt
+++ b/bpf_generic/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SOURCES
-	kernel_version_test.cpp
+	system_utils_test.cpp
 )
 PREPEND(SOURCES_FULL "${CMAKE_CURRENT_LIST_DIR}/cpp" ${SOURCES})
 

--- a/bpf_generic/test/cpp/system_utils_test.cpp
+++ b/bpf_generic/test/cpp/system_utils_test.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 #include <gtest/gtest.h>
-#include "kernel_version.h"
+#include "system_utils.h"
 #include "mock_system_calls.h"
 #include <algorithm>
 #include <linux/version.h>
@@ -254,4 +254,86 @@ TEST_F(VersionOnGenericDistroTest, test_4_17_2_dash) {
 
 TEST_F(VersionOnGenericDistroTest, test_centos_similar_candidate) {
 	checkParsedVersion("4.18.0-305.3.1.el8.x86_64", 4, 18, 0);
+}
+
+class NumPossibleCpusTest : public testing::Test {
+protected:
+	void expectFileContent(std::string_view content) {
+		std::FILE* dummyFile{reinterpret_cast<std::FILE*>(0x123456)};
+		EXPECT_CALL(sysCalls, fopen)
+			.WillOnce(Return(dummyFile));
+		EXPECT_CALL(sysCalls, fread)
+			.WillOnce(DoAll(
+				SetArrayArgument<0>(content.cbegin(), content.cend()),
+				Return(content.size())));
+		EXPECT_CALL(sysCalls, fclose)
+			.WillOnce(Return());
+	}
+
+	void expectFileMissing() {
+		EXPECT_CALL(sysCalls, fopen)
+			.WillOnce(Return(nullptr));
+	}
+
+	MockSystemCalls sysCalls;
+};
+
+TEST_F(NumPossibleCpusTest, single_cpu) {
+	expectFileContent("0");
+	auto result{getNumPossibleCpus(sysCalls)};
+	ASSERT_TRUE(result);
+	EXPECT_EQ(*result, 1u);
+}
+
+TEST_F(NumPossibleCpusTest, single_range) {
+	expectFileContent("0-3");
+	auto result{getNumPossibleCpus(sysCalls)};
+	ASSERT_TRUE(result);
+	EXPECT_EQ(*result, 4u);
+}
+
+TEST_F(NumPossibleCpusTest, single_range_with_newline) {
+	expectFileContent("0-7\n");
+	auto result{getNumPossibleCpus(sysCalls)};
+	ASSERT_TRUE(result);
+	EXPECT_EQ(*result, 8u);
+}
+
+TEST_F(NumPossibleCpusTest, mixed_ranges_and_singletons) {
+	expectFileContent("0,2-5,7");
+	auto result{getNumPossibleCpus(sysCalls)};
+	ASSERT_TRUE(result);
+	EXPECT_EQ(*result, 6u);
+}
+
+TEST_F(NumPossibleCpusTest, multiple_ranges) {
+	expectFileContent("0-1,4-7");
+	auto result{getNumPossibleCpus(sysCalls)};
+	ASSERT_TRUE(result);
+	EXPECT_EQ(*result, 6u);
+}
+
+TEST_F(NumPossibleCpusTest, large_range) {
+	expectFileContent("0-127");
+	auto result{getNumPossibleCpus(sysCalls)};
+	ASSERT_TRUE(result);
+	EXPECT_EQ(*result, 128u);
+}
+
+TEST_F(NumPossibleCpusTest, file_missing) {
+	expectFileMissing();
+	auto result{getNumPossibleCpus(sysCalls)};
+	EXPECT_FALSE(result);
+}
+
+TEST_F(NumPossibleCpusTest, empty_file) {
+	expectFileContent("");
+	auto result{getNumPossibleCpus(sysCalls)};
+	EXPECT_FALSE(result);
+}
+
+TEST_F(NumPossibleCpusTest, only_whitespace) {
+	expectFileContent("   \n");
+	auto result{getNumPossibleCpus(sysCalls)};
+	EXPECT_FALSE(result);
 }

--- a/bpf_program/legacy/maps.h
+++ b/bpf_program/legacy/maps.h
@@ -145,3 +145,12 @@ struct bpf_map_def SEC("maps") map_sends = {
 	.max_entries = MAP_MAX_ENTRIES
 };
 
+// Map with only one element at 0-key, representing debug counters for BPF program.
+// PERCPU_ARRAY: each CPU gets its own copy, so plain ++ is safe (no atomics needed).
+struct bpf_map_def SEC("maps") bpf_debug_counters = {
+	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size = sizeof(uint32_t),
+	.value_size = sizeof(struct bpf_debug_counters_t),
+	.max_entries = 1
+};
+

--- a/bpf_program/maps.h
+++ b/bpf_program/maps.h
@@ -146,3 +146,12 @@ struct {
 	__uint(max_entries, MAP_MAX_ENTRIES);
 } map_sends SEC(".maps");
 
+// Map with only one element at 0-key, representing debug counters for BPF program.
+// PERCPU_ARRAY: each CPU gets its own copy, so plain ++ is safe (no atomics needed).
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, __u32);
+	__type(value, struct bpf_debug_counters_t);
+	__uint(max_entries, 1);
+} bpf_debug_counters SEC(".maps");
+

--- a/bpf_program/metrics_utilities.h
+++ b/bpf_program/metrics_utilities.h
@@ -42,6 +42,7 @@ static void update_stats(void *tuple, enum protocol proto, uint64_t sent, uint64
 	}
 
 	if (stats == NULL) {
+		INC_DEBUG_COUNTER(stats_updating_failures);
 		return;
 	}
 
@@ -68,6 +69,7 @@ static void update_tcp_stats(void *tuple, enum protocol proto, struct guess_stat
 	}
 
 	if (stats == NULL) {
+		INC_DEBUG_COUNTER(tcp_stats_updating_failures);
 		return;
 	}
 

--- a/bpf_program/nettracer-bpf.h
+++ b/bpf_program/nettracer-bpf.h
@@ -178,6 +178,7 @@ struct bpf_log_event_t {
 	int64_t args[10];
 };
 
+// All fields must be uint64_t for the generic handling to work correctly.
 struct bpf_debug_counters_t {
 	uint64_t update_ipv4_on_connect_failures;
 	uint64_t update_ipv6_on_connect_failures;

--- a/bpf_program/nettracer-bpf.h
+++ b/bpf_program/nettracer-bpf.h
@@ -177,3 +177,43 @@ struct bpf_log_event_t {
 	uint8_t padding[3];
 	int64_t args[10];
 };
+
+struct bpf_debug_counters_t {
+	uint64_t update_ipv4_on_connect_failures;
+	uint64_t update_ipv6_on_connect_failures;
+	uint64_t read_ipv4_on_connect_failures;
+	uint64_t read_ipv6_on_connect_failures;
+	uint64_t read_ipv4_on_close_failures;
+	uint64_t read_ipv6_on_close_failures;
+	uint64_t read_ipv4_on_accept_failures;
+	uint64_t read_ipv6_on_accept_failures;
+	uint64_t update_ipv4_on_accept_failures;
+	uint64_t update_ipv6_on_accept_failures;
+	uint64_t lookup_ipv4_on_close_failures;
+	uint64_t lookup_ipv6_on_close_failures;
+	uint64_t status_lookup_failures;
+	uint64_t stats_updating_failures;
+	uint64_t tcp_stats_updating_failures;
+	uint64_t perf_output_ipv4_on_connect_failures;
+	uint64_t perf_output_ipv6_on_connect_failures;
+	uint64_t perf_output_ipv4_on_accept_failures;
+	uint64_t perf_output_ipv6_on_accept_failures;
+	uint64_t perf_output_ipv4_on_close_failures;
+	uint64_t perf_output_ipv6_on_close_failures;
+	uint64_t connectsock_ipv4_update_failures;
+	uint64_t connectsock_ipv6_update_failures;
+	uint64_t map_sends_update_failures;
+};
+
+// Helper to safely increment a field of bpf_debug_counters_t from BPF code.
+// Relies on bpf_debug_counters being a PERCPU_ARRAY map of size 1 at key 0,
+// so plain ++ is race-free across CPUs (no __sync_fetch_and_add needed).
+// The NULL check is required by the BPF verifier on every map lookup result.
+#define INC_DEBUG_COUNTER(field) do {                                          \
+	uint32_t _dbg_zero = 0;                                                    \
+	struct bpf_debug_counters_t *_dbg_c =                                      \
+		bpf_map_lookup_elem(&bpf_debug_counters, &_dbg_zero);                  \
+	if (_dbg_c) {                                                              \
+		_dbg_c->field++;                                                       \
+	}                                                                          \
+} while (0)

--- a/bpf_program/probes/connections.h
+++ b/bpf_program/probes/connections.h
@@ -104,6 +104,8 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 	if (bpf_map_update_elem(&tuplepid_ipv4, &t, &p, BPF_ANY) < 0) {
 		INC_DEBUG_COUNTER(update_ipv4_on_connect_failures);
 		LOG_DEBUG_BPF(ctx, "Connect missed, reached max conns?: {:d}:{:d} {:d}:{:d} {:d}", t.saddr, t.sport, t.daddr, t.dport, pid >> 32);
+		BPF_PRINTK("Update failed connectv4/src: %x :%d", t.saddr, t.sport);
+		BPF_PRINTK("Update failed connectv4/dst: %x :%d", t.daddr, t.dport);
 	}
 
 	struct tcp_ipv4_event_t evt = convert_ipv4_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CONNECT, pid >> 32);
@@ -178,6 +180,8 @@ int kretprobe__tcp_v6_connect(struct pt_regs *ctx)
 	if (bpf_map_update_elem(&tuplepid_ipv6, &t, &p, BPF_ANY) < 0) {
 		INC_DEBUG_COUNTER(update_ipv6_on_connect_failures);
 		LOG_DEBUG_BPF(ctx, "Connect v6 missed, reached max conns?: {:d}{:d}:{:d} {:d}{:d}:{:d} {:d}", t.saddr_h, t.saddr_l, t.sport, t.daddr_h, t.daddr_l, t.dport, pid >> 32);
+		BPF_PRINTK("Update failed connectv6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
+		BPF_PRINTK("Update failed connectv6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 	}
 
 	struct tcp_ipv6_event_t evt = convert_ipv6_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CONNECT, pid >> 32);
@@ -224,6 +228,8 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 			if (bpf_map_update_elem(&tuplepid_ipv4, &t, &p, BPF_ANY) < 0) {
 				INC_DEBUG_COUNTER(update_ipv4_on_accept_failures);
 				LOG_DEBUG_BPF(ctx, "Accept missed, reached max conns?: {:d}:{:d} {:d}:{:d} {:d}", t.saddr, t.sport, t.daddr, t.dport, pid >> 32);
+				BPF_PRINTK("Update failed acceptv4/src: %x :%d", t.saddr, t.sport);
+				BPF_PRINTK("Update failed acceptv4/dst: %x :%d", t.daddr, t.dport);
 			}
 			if (bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt)) < 0) {
 				INC_DEBUG_COUNTER(perf_output_ipv4_on_accept_failures);
@@ -257,6 +263,8 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 						t.daddr_l,
 						t.dport,
 						pid >> 32);
+				BPF_PRINTK("Update failed acceptv6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
+				BPF_PRINTK("Update failed acceptv6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 			}
 			if (bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt)) < 0) {
 				INC_DEBUG_COUNTER(perf_output_ipv6_on_accept_failures);
@@ -299,6 +307,8 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 		if (pp == NULL) {
 			INC_DEBUG_COUNTER(lookup_ipv4_on_close_failures);
 			LOG_DEBUG_BPF(ctx, "Missing tuplepid entry: {:d}:{:d} {:d}:{:d}", t.saddr, t.sport, t.daddr, t.dport);
+			BPF_PRINTK("Update failed closev4/src: %x :%d", t.saddr, t.sport);
+			BPF_PRINTK("Update failed closev4/dst: %x :%d", t.daddr, t.dport);
 		} else {
 			pp->state = CONN_CLOSED;
 		}
@@ -330,6 +340,8 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 					t.daddr_h,
 					t.daddr_l,
 					t.dport);
+			BPF_PRINTK("Update failed closev6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
+			BPF_PRINTK("Update failed closev6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 		} else {
 			pp->state = CONN_CLOSED;
 		}

--- a/bpf_program/probes/connections.h
+++ b/bpf_program/probes/connections.h
@@ -36,15 +36,15 @@
 #define LOG_DEBUG_BPF(...)
 #endif
 
-#include "print.h"
-
 #ifdef LEGACY_BPF
 SEC("kprobe/tcp_v4_connect")
 int kprobe__tcp_v4_connect( struct pt_regs *ctx) {
 	struct sock *sk;
 	uint64_t pid = bpf_get_current_pid_tgid();
 	sk = (struct sock *) PT_REGS_PARM1(ctx);
-	bpf_map_update_elem(&connectsock_ipv4, &pid, &sk, BPF_ANY);
+	if (bpf_map_update_elem(&connectsock_ipv4, &pid, &sk, BPF_ANY) < 0) {
+		INC_DEBUG_COUNTER(connectsock_ipv4_update_failures);
+	}
 	return 0;
 }
 
@@ -52,7 +52,9 @@ int kprobe__tcp_v4_connect( struct pt_regs *ctx) {
 SEC("kprobe/tcp_v4_connect")
 int BPF_KPROBE(kprobe__tcp_v4_connect, struct sock *sk, struct sockaddr *uaddr, int addr_len){
 	uint64_t pid = bpf_get_current_pid_tgid();
-	bpf_map_update_elem(&connectsock_ipv4, &pid, &sk, BPF_ANY);
+	if (bpf_map_update_elem(&connectsock_ipv4, &pid, &sk, BPF_ANY) < 0) {
+		INC_DEBUG_COUNTER(connectsock_ipv4_update_failures);
+	}
 	return 0;
 }
 #endif
@@ -83,11 +85,13 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 
 	struct ipv4_tuple_t t = { };
 	if (!read_ipv4_tuple(&t, status, skp)) {
+		INC_DEBUG_COUNTER(read_ipv4_on_connect_failures);
 		return 0;
 	}
 
@@ -98,13 +102,14 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 	struct pid_comm_t p = {.pid = pid, .state = CONN_ACTIVE};
 	uint32_t cpu = bpf_get_smp_processor_id();
 	if (bpf_map_update_elem(&tuplepid_ipv4, &t, &p, BPF_ANY) < 0) {
+		INC_DEBUG_COUNTER(update_ipv4_on_connect_failures);
 		LOG_DEBUG_BPF(ctx, "Connect missed, reached max conns?: {:d}:{:d} {:d}:{:d} {:d}", t.saddr, t.sport, t.daddr, t.dport, pid >> 32);
-		BPF_PRINTK("Update failed connectv4/src: %x :%d", t.saddr, t.sport);
-		BPF_PRINTK("Update failed connectv4/dst: %x :%d", t.daddr, t.dport);
 	}
 
 	struct tcp_ipv4_event_t evt = convert_ipv4_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CONNECT, pid >> 32);
-	bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt));
+	if (bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt)) < 0) {
+		INC_DEBUG_COUNTER(perf_output_ipv4_on_connect_failures);
+	}
 	return 0;
 }
 
@@ -116,7 +121,9 @@ int kprobe__tcp_v6_connect(struct pt_regs *ctx)
 
 	sk = (struct sock *) PT_REGS_PARM1(ctx);
 
-	bpf_map_update_elem(&connectsock_ipv6, &pid, &sk, BPF_ANY);
+	if (bpf_map_update_elem(&connectsock_ipv6, &pid, &sk, BPF_ANY) < 0) {
+		INC_DEBUG_COUNTER(connectsock_ipv6_update_failures);
+	}
 	return 0;
 }
 
@@ -146,6 +153,7 @@ int kretprobe__tcp_v6_connect(struct pt_regs *ctx)
 
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL || status->state == GUESS_STATE_UNINITIALIZED) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 #ifdef LEGACY_BPF
@@ -155,6 +163,7 @@ int kretprobe__tcp_v6_connect(struct pt_regs *ctx)
 #endif
 	struct ipv6_tuple_t t = { };
 	if (!read_ipv6_tuple(&t, status, skp)) {
+		INC_DEBUG_COUNTER(read_ipv6_on_connect_failures);
 		return 0;
 	}
 
@@ -167,13 +176,14 @@ int kretprobe__tcp_v6_connect(struct pt_regs *ctx)
 	uint32_t cpu = bpf_get_smp_processor_id();
 
 	if (bpf_map_update_elem(&tuplepid_ipv6, &t, &p, BPF_ANY) < 0) {
+		INC_DEBUG_COUNTER(update_ipv6_on_connect_failures);
 		LOG_DEBUG_BPF(ctx, "Connect v6 missed, reached max conns?: {:d}{:d}:{:d} {:d}{:d}:{:d} {:d}", t.saddr_h, t.saddr_l, t.sport, t.daddr_h, t.daddr_l, t.dport, pid >> 32);
-		BPF_PRINTK("Update failed connectv6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
-		BPF_PRINTK("Update failed connectv6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 	}
 
 	struct tcp_ipv6_event_t evt = convert_ipv6_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CONNECT, pid >> 32);
-	bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt));
+	if (bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt)) < 0) {
+		INC_DEBUG_COUNTER(perf_output_ipv6_on_connect_failures);
+	}
 	return 0;
 }
 
@@ -191,12 +201,14 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 
 	if (check_family(newsk, AF_INET)) {
 		struct ipv4_tuple_t t = { };
 		if (!read_ipv4_tuple(&t, status, newsk)){
+			INC_DEBUG_COUNTER(read_ipv4_on_accept_failures);
 			return 0;
 		}
 
@@ -210,15 +222,17 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 		if (evt.saddr != 0 && evt.daddr != 0 && evt.sport != 0 && evt.dport != 0) {
 			struct pid_comm_t p = {.pid = pid, .state = CONN_ACTIVE};
 			if (bpf_map_update_elem(&tuplepid_ipv4, &t, &p, BPF_ANY) < 0) {
+				INC_DEBUG_COUNTER(update_ipv4_on_accept_failures);
 				LOG_DEBUG_BPF(ctx, "Accept missed, reached max conns?: {:d}:{:d} {:d}:{:d} {:d}", t.saddr, t.sport, t.daddr, t.dport, pid >> 32);
-				BPF_PRINTK("Update failed acceptv4/src: %x :%d", t.saddr, t.sport);
-				BPF_PRINTK("Update failed acceptv4/dst: %x :%d", t.daddr, t.dport);
 			}
-			bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt));
+			if (bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt)) < 0) {
+				INC_DEBUG_COUNTER(perf_output_ipv4_on_accept_failures);
+			}
 		}
 	} else if (check_family(newsk, AF_INET6)) {
 		struct ipv6_tuple_t t = {};
 		if (!read_ipv6_tuple(&t, status, newsk)) {
+			INC_DEBUG_COUNTER(read_ipv6_on_accept_failures);
 			return 0;
 		}
 
@@ -232,6 +246,7 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 		if ((evt.saddr_h || evt.saddr_l) && (evt.daddr_h || evt.daddr_l) && evt.sport != 0 && evt.dport != 0) {
 			struct pid_comm_t p = {.pid = pid, .state = CONN_ACTIVE};
 			if (bpf_map_update_elem(&tuplepid_ipv6, &t, &p, BPF_ANY) < 0) {
+				INC_DEBUG_COUNTER(update_ipv6_on_accept_failures);
 				LOG_DEBUG_BPF(
 						ctx,
 						"Accept v6 missed, reached max conns?: {:d}{:d}:{:d} {:d}{:d}:{:d} {:d}",
@@ -242,10 +257,10 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 						t.daddr_l,
 						t.dport,
 						pid >> 32);
-				BPF_PRINTK("Update failed acceptv6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
-				BPF_PRINTK("Update failed acceptv6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 			}
-			bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt));
+			if (bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt)) < 0) {
+				INC_DEBUG_COUNTER(perf_output_ipv6_on_accept_failures);
+			}
 		}
 	}
 	return 0;
@@ -263,12 +278,14 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 
 	if (check_family(sk, AF_INET)) {
 		struct ipv4_tuple_t t = {};
 		if (!read_ipv4_tuple(&t, status, sk)){
+			INC_DEBUG_COUNTER(read_ipv4_on_close_failures);
 			return 0;
 		}
 
@@ -280,18 +297,20 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 		struct pid_comm_t* pp;
 		pp = bpf_map_lookup_elem(&tuplepid_ipv4, &t);
 		if (pp == NULL) {
+			INC_DEBUG_COUNTER(lookup_ipv4_on_close_failures);
 			LOG_DEBUG_BPF(ctx, "Missing tuplepid entry: {:d}:{:d} {:d}:{:d}", t.saddr, t.sport, t.daddr, t.dport);
-			BPF_PRINTK("Update failed closev4/src: %x :%d", t.saddr, t.sport);
-			BPF_PRINTK("Update failed closev4/dst: %x :%d", t.daddr, t.dport);
 		} else {
 			pp->state = CONN_CLOSED;
 		}
 
 		struct tcp_ipv4_event_t evt = convert_ipv4_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CLOSE, pid >> 32);
-		bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt));
+		if (bpf_perf_event_output(ctx, &tcp_event_ipv4, cpu, &evt, sizeof(evt)) < 0) {
+			INC_DEBUG_COUNTER(perf_output_ipv4_on_close_failures);
+		}
 	} else if (check_family(sk, AF_INET6)) {
 		struct ipv6_tuple_t t = {};
 		if (!read_ipv6_tuple(&t, status, sk)) {
+			INC_DEBUG_COUNTER(read_ipv6_on_close_failures);
 			return 0;
 		}
 		if (filter_ipv6(&t)) {
@@ -301,6 +320,7 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 		struct pid_comm_t* pp;
 		pp = bpf_map_lookup_elem(&tuplepid_ipv6, &t);
 		if (pp == NULL) {
+			INC_DEBUG_COUNTER(lookup_ipv6_on_close_failures);
 			LOG_DEBUG_BPF(
 					ctx,
 					"Missing tuplepid entry: {:d}{:d}:{:d} {:d}{:d}:{:d}",
@@ -310,14 +330,14 @@ int kprobe__tcp_close(struct pt_regs *ctx)
 					t.daddr_h,
 					t.daddr_l,
 					t.dport);
-			BPF_PRINTK("Update failed closev6/src: %lx %lx :%d", t.saddr_h, t.saddr_l, t.sport);
-			BPF_PRINTK("Update failed closev6/dst: %lx %lx :%d", t.daddr_h, t.daddr_l, t.dport);
 		} else {
 			pp->state = CONN_CLOSED;
 		}
 
 		struct tcp_ipv6_event_t evt = convert_ipv6_tuple_to_event(t, cpu, TCP_EVENT_TYPE_CLOSE, pid >> 32);
-		bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt));
+		if (bpf_perf_event_output(ctx, &tcp_event_ipv6, cpu, &evt, sizeof(evt)) < 0) {
+			INC_DEBUG_COUNTER(perf_output_ipv6_on_close_failures);
+		}
 	}
 	return 0;
 }

--- a/bpf_program/probes/metrics.h
+++ b/bpf_program/probes/metrics.h
@@ -41,6 +41,7 @@ static int send_metric(struct sock* sk, int32_t bytes_sent) {
 	uint32_t zero = 0;
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 
@@ -78,7 +79,9 @@ SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
 	struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
 	uint64_t pid = bpf_get_current_pid_tgid();
-	bpf_map_update_elem(&map_sends, &pid, &sk, BPF_ANY);
+	if (bpf_map_update_elem(&map_sends, &pid, &sk, BPF_ANY) < 0) {
+		INC_DEBUG_COUNTER(map_sends_update_failures);
+	}
 	return 0;
 }
 
@@ -118,6 +121,7 @@ int kprobe__tcp_cleanup_rbuf(struct pt_regs* ctx) {
 	uint32_t zero = 0;
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 
@@ -159,6 +163,7 @@ int kprobe__tcp_retransmit_skb(struct pt_regs* ctx) {
 	uint32_t zero = 0;
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 
@@ -178,6 +183,7 @@ int kprobe__tcp_retransmit_skb(struct pt_regs* ctx) {
 		struct tcp_stats_t* stats = bpf_map_lookup_elem(&tcp_stats_ipv4, &ipv4_tuple);
 
 		if (stats == NULL) {
+			INC_DEBUG_COUNTER(tcp_stats_updating_failures);
 			return 0;
 		}
 
@@ -200,6 +206,7 @@ int kprobe__tcp_retransmit_skb(struct pt_regs* ctx) {
 		bpf_map_update_elem(&tcp_stats_ipv6, &ipv6_tuple, &empty, BPF_NOEXIST);
 		stats = bpf_map_lookup_elem(&tcp_stats_ipv6, &ipv6_tuple);
 		if (stats == NULL) {
+			INC_DEBUG_COUNTER(tcp_stats_updating_failures);
 			return 0;
 		}
 

--- a/bpf_program/tuples_utilities.h
+++ b/bpf_program/tuples_utilities.h
@@ -65,6 +65,7 @@ static bool check_family(struct sock *sk, uint16_t expected_family) {
 	uint32_t zero = 0;
 	status = bpf_map_lookup_elem(&nettracer_status, &zero);
 	if (status == NULL) {
+		INC_DEBUG_COUNTER(status_lookup_failures);
 		return 0;
 	}
 

--- a/libnettracer/src/CMakeLists.txt
+++ b/libnettracer/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     bpf_events.cpp
+	bpf_debug_counters.cpp
 	config_watcher.cpp
 	connections_printing.cpp
 	inotify_watcher.cpp
@@ -13,6 +14,7 @@ set(SOURCES
 
 set(HEADERS
     bpf_events.h
+	bpf_debug_counters.h
 	config_watcher.h
 	connections_printing.h
 	inotify_watcher.h

--- a/libnettracer/src/bpf_debug_counters.cpp
+++ b/libnettracer/src/bpf_debug_counters.cpp
@@ -25,8 +25,6 @@ namespace nettracer {
 
 static_assert(sizeof(BpfDebugCounters) == kBpfDebugCountersFieldCount * sizeof(std::uint64_t),
 	"BpfDebugCounters layout has drifted from kBpfDebugCountersFieldCount; update both together");
-static_assert(sizeof(BpfDebugCounters) % 8 == 0,
-	"BpfDebugCounters must be 8-byte aligned for PERCPU_ARRAY lookup");
 
 const std::array<BpfDebugCounterField, kBpfDebugCountersFieldCount>& bpfDebugCounterFields() {
 	static const std::array<BpfDebugCounterField, kBpfDebugCountersFieldCount> fields = {{
@@ -90,7 +88,7 @@ std::string formatNonZeroFields(const BpfDebugCounters& counters) {
 		first = false;
 	}
 	if (first) {
-		return "(all zero)";
+		return "";
 	}
 	return fmt::to_string(out);
 }

--- a/libnettracer/src/bpf_debug_counters.cpp
+++ b/libnettracer/src/bpf_debug_counters.cpp
@@ -1,0 +1,113 @@
+/*
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#include "bpf_debug_counters.h"
+
+#include <fmt/format.h>
+
+#include <cstring>
+#include <iterator>
+#include <vector>
+
+namespace nettracer {
+
+static_assert(sizeof(BpfDebugCounters) == kBpfDebugCountersFieldCount * sizeof(std::uint64_t),
+	"BpfDebugCounters layout has drifted from kBpfDebugCountersFieldCount; update both together");
+static_assert(sizeof(BpfDebugCounters) % 8 == 0,
+	"BpfDebugCounters must be 8-byte aligned for PERCPU_ARRAY lookup");
+
+const std::array<BpfDebugCounterField, kBpfDebugCountersFieldCount>& bpfDebugCounterFields() {
+	static const std::array<BpfDebugCounterField, kBpfDebugCountersFieldCount> fields = {{
+		{"update_ipv4_on_connect_failures",      &BpfDebugCounters::update_ipv4_on_connect_failures},
+		{"update_ipv6_on_connect_failures",      &BpfDebugCounters::update_ipv6_on_connect_failures},
+		{"read_ipv4_on_connect_failures",        &BpfDebugCounters::read_ipv4_on_connect_failures},
+		{"read_ipv6_on_connect_failures",        &BpfDebugCounters::read_ipv6_on_connect_failures},
+		{"read_ipv4_on_close_failures",          &BpfDebugCounters::read_ipv4_on_close_failures},
+		{"read_ipv6_on_close_failures",          &BpfDebugCounters::read_ipv6_on_close_failures},
+		{"read_ipv4_on_accept_failures",         &BpfDebugCounters::read_ipv4_on_accept_failures},
+		{"read_ipv6_on_accept_failures",         &BpfDebugCounters::read_ipv6_on_accept_failures},
+		{"update_ipv4_on_accept_failures",       &BpfDebugCounters::update_ipv4_on_accept_failures},
+		{"update_ipv6_on_accept_failures",       &BpfDebugCounters::update_ipv6_on_accept_failures},
+		{"lookup_ipv4_on_close_failures",        &BpfDebugCounters::lookup_ipv4_on_close_failures},
+		{"lookup_ipv6_on_close_failures",        &BpfDebugCounters::lookup_ipv6_on_close_failures},
+		{"status_lookup_failures",               &BpfDebugCounters::status_lookup_failures},
+		{"stats_updating_failures",              &BpfDebugCounters::stats_updating_failures},
+		{"tcp_stats_updating_failures",          &BpfDebugCounters::tcp_stats_updating_failures},
+		{"perf_output_ipv4_on_connect_failures", &BpfDebugCounters::perf_output_ipv4_on_connect_failures},
+		{"perf_output_ipv6_on_connect_failures", &BpfDebugCounters::perf_output_ipv6_on_connect_failures},
+		{"perf_output_ipv4_on_accept_failures",  &BpfDebugCounters::perf_output_ipv4_on_accept_failures},
+		{"perf_output_ipv6_on_accept_failures",  &BpfDebugCounters::perf_output_ipv6_on_accept_failures},
+		{"perf_output_ipv4_on_close_failures",   &BpfDebugCounters::perf_output_ipv4_on_close_failures},
+		{"perf_output_ipv6_on_close_failures",   &BpfDebugCounters::perf_output_ipv6_on_close_failures},
+		{"connectsock_ipv4_update_failures",     &BpfDebugCounters::connectsock_ipv4_update_failures},
+		{"connectsock_ipv6_update_failures",     &BpfDebugCounters::connectsock_ipv6_update_failures},
+		{"map_sends_update_failures",            &BpfDebugCounters::map_sends_update_failures},
+	}};
+	return fields;
+}
+
+BpfDebugCounters subtractBpfDebugCounters(const BpfDebugCounters& current, const BpfDebugCounters& previous) {
+	BpfDebugCounters result{};
+	for (const auto& field : bpfDebugCounterFields()) {
+		result.*(field.pointer) = current.*(field.pointer) - previous.*(field.pointer);
+	}
+	return result;
+}
+
+BpfDebugCounters aggregatePerCpuBuffer(const BpfDebugCounters* perCpuBuffer, unsigned numCpus) {
+	BpfDebugCounters result{};
+	const auto& fields = bpfDebugCounterFields();
+	for (unsigned cpu = 0; cpu < numCpus; ++cpu) {
+		const auto& perCpu = perCpuBuffer[cpu];
+		for (const auto& field : fields) {
+			result.*(field.pointer) += perCpu.*(field.pointer);
+		}
+	}
+	return result;
+}
+
+std::string formatNonZeroFields(const BpfDebugCounters& counters) {
+	fmt::memory_buffer out;
+	bool first = true;
+	for (const auto& field : bpfDebugCounterFields()) {
+		const std::uint64_t value = counters.*(field.pointer);
+		if (value == 0) {
+			continue;
+		}
+		fmt::format_to(std::back_inserter(out), "{}{}={}", first ? "" : " ", field.name, value);
+		first = false;
+	}
+	if (first) {
+		return "(all zero)";
+	}
+	return fmt::to_string(out);
+}
+
+BpfDebugCountersReader::BpfDebugCountersReader(int mapFd, unsigned numPossibleCpus, const bpf::BPFMapsWrapper& mapsWrapper)
+	: mapFd(mapFd), numPossibleCpus(numPossibleCpus), mapsWrapper(mapsWrapper) {}
+
+std::optional<BpfDebugCounters> BpfDebugCountersReader::readAndAggregate() const {
+	// For a PERCPU_ARRAY the kernel expects the user buffer to be
+	// num_possible_cpus * round_up(value_size, 8) bytes long. The static_assert
+	// at the top of this file guarantees sizeof(BpfDebugCounters) is 8-aligned.
+	std::vector<BpfDebugCounters> perCpuBuffer(numPossibleCpus);
+	std::uint32_t key{0};
+	if (!mapsWrapper.lookupElement(mapFd, &key, perCpuBuffer.data())) {
+		return std::nullopt;
+	}
+	return aggregatePerCpuBuffer(perCpuBuffer.data(), numPossibleCpus);
+}
+
+} // namespace nettracer

--- a/libnettracer/src/bpf_debug_counters.h
+++ b/libnettracer/src/bpf_debug_counters.h
@@ -1,0 +1,73 @@
+/*
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#pragma once
+
+#include "bpf_generic/src/bpf_wrapper.h"
+#include "bpf_program/nettracer-bpf.h"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace nettracer {
+
+// User-space mirror of the BPF-side `struct bpf_debug_counters_t`.
+// The layout is identical, so we expose it via a type alias and avoid
+// duplicating the field list. The struct lives in bpf_program/nettracer-bpf.h.
+using BpfDebugCounters = bpf_debug_counters_t;
+
+// Number of uint64_t counters in BpfDebugCounters. A static_assert in the .cpp
+// verifies this matches sizeof(BpfDebugCounters).
+inline constexpr std::size_t kBpfDebugCountersFieldCount = 24;
+
+// (name, pointer-to-member) pair used to iterate over all counter fields
+// generically for aggregation, subtraction and formatting.
+struct BpfDebugCounterField {
+	std::string_view name;
+	std::uint64_t BpfDebugCounters::* pointer;
+};
+
+// Returns the static field table covering every counter in BpfDebugCounters.
+const std::array<BpfDebugCounterField, kBpfDebugCountersFieldCount>& bpfDebugCounterFields();
+
+// Returns current minus previous, field by field.
+BpfDebugCounters subtractBpfDebugCounters(const BpfDebugCounters& current, const BpfDebugCounters& previous);
+
+// Aggregates a per-CPU buffer (numCpus entries of BpfDebugCounters) into a
+// single BpfDebugCounters by summing every field across CPUs.
+BpfDebugCounters aggregatePerCpuBuffer(const BpfDebugCounters* perCpuBuffer, unsigned numCpus);
+
+// Formats only the fields that are non-zero as "name=value" pairs separated by
+// spaces. Returns "(all zero)" when every field is zero.
+std::string formatNonZeroFields(const BpfDebugCounters& counters);
+
+class BpfDebugCountersReader {
+public:
+	BpfDebugCountersReader(int mapFd, unsigned numPossibleCpus, const bpf::BPFMapsWrapper& mapsWrapper);
+
+	// Reads the BPF PERCPU_ARRAY map at key 0 and aggregates across all CPUs.
+	// Returns std::nullopt if the map lookup failed.
+	std::optional<BpfDebugCounters> readAndAggregate() const;
+
+private:
+	int mapFd;
+	unsigned numPossibleCpus;
+	const bpf::BPFMapsWrapper& mapsWrapper;
+};
+
+} // namespace nettracer

--- a/libnettracer/src/bpf_debug_counters.h
+++ b/libnettracer/src/bpf_debug_counters.h
@@ -31,9 +31,8 @@ namespace nettracer {
 // duplicating the field list. The struct lives in bpf_program/nettracer-bpf.h.
 using BpfDebugCounters = bpf_debug_counters_t;
 
-// Number of uint64_t counters in BpfDebugCounters. A static_assert in the .cpp
-// verifies this matches sizeof(BpfDebugCounters).
-inline constexpr std::size_t kBpfDebugCountersFieldCount = 24;
+// Number of uint64_t counters in BpfDebugCounters.
+constexpr std::size_t kBpfDebugCountersFieldCount = sizeof(bpf_debug_counters_t) / sizeof(uint64_t);;
 
 // (name, pointer-to-member) pair used to iterate over all counter fields
 // generically for aggregation, subtraction and formatting.

--- a/libnettracer/test/CMakeLists.txt
+++ b/libnettracer/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(SOURCES
+	bpf_debug_counters_test.cpp
 	connection_test.cpp
 	connections_printing_test.cpp
 	mock_bpf_maps_test.cpp

--- a/libnettracer/test/cpp/bpf_debug_counters_test.cpp
+++ b/libnettracer/test/cpp/bpf_debug_counters_test.cpp
@@ -1,0 +1,179 @@
+/*
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#include "bpf_debug_counters.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+
+namespace {
+
+class StubMapsWrapper : public bpf::BPFMapsWrapper {
+public:
+	std::vector<bpf_debug_counters_t> perCpuValues;
+	bool lookupShouldFail{false};
+	mutable int lookupCallCount{0};
+	mutable int lastFd{-1};
+	mutable std::uint32_t lastKey{~0u};
+
+	bool lookupElement(int fd, const void* key, void* value) const override {
+		++lookupCallCount;
+		lastFd = fd;
+		lastKey = *static_cast<const std::uint32_t*>(key);
+		if (lookupShouldFail) {
+			return false;
+		}
+		std::memcpy(value, perCpuValues.data(), perCpuValues.size() * sizeof(bpf_debug_counters_t));
+		return true;
+	}
+};
+
+bpf_debug_counters_t makeAllZero() {
+	bpf_debug_counters_t c{};
+	return c;
+}
+
+} // namespace
+
+TEST(BpfDebugCountersAggregation, sums_a_single_field_across_cpus) {
+	bpf_debug_counters_t cpu0{};
+	cpu0.status_lookup_failures = 3;
+	bpf_debug_counters_t cpu1{};
+	cpu1.status_lookup_failures = 7;
+	bpf_debug_counters_t cpu2{};
+	cpu2.status_lookup_failures = 0;
+	bpf_debug_counters_t cpu3{};
+	cpu3.status_lookup_failures = 5;
+	std::vector<bpf_debug_counters_t> buffer{cpu0, cpu1, cpu2, cpu3};
+
+	auto result = nettracer::aggregatePerCpuBuffer(buffer.data(), buffer.size());
+
+	EXPECT_EQ(result.status_lookup_failures, 15u);
+	EXPECT_EQ(result.update_ipv4_on_connect_failures, 0u);
+	EXPECT_EQ(result.map_sends_update_failures, 0u);
+}
+
+TEST(BpfDebugCountersAggregation, sums_multiple_fields_independently) {
+	bpf_debug_counters_t cpu0{};
+	cpu0.update_ipv4_on_connect_failures = 1;
+	cpu0.read_ipv6_on_accept_failures = 4;
+	cpu0.map_sends_update_failures = 100;
+	bpf_debug_counters_t cpu1{};
+	cpu1.update_ipv4_on_connect_failures = 2;
+	cpu1.read_ipv6_on_accept_failures = 0;
+	cpu1.map_sends_update_failures = 50;
+	std::vector<bpf_debug_counters_t> buffer{cpu0, cpu1};
+
+	auto result = nettracer::aggregatePerCpuBuffer(buffer.data(), buffer.size());
+
+	EXPECT_EQ(result.update_ipv4_on_connect_failures, 3u);
+	EXPECT_EQ(result.read_ipv6_on_accept_failures, 4u);
+	EXPECT_EQ(result.map_sends_update_failures, 150u);
+}
+
+TEST(BpfDebugCountersAggregation, all_zero_buffer_yields_all_zero_result) {
+	std::vector<bpf_debug_counters_t> buffer(4, makeAllZero());
+	auto result = nettracer::aggregatePerCpuBuffer(buffer.data(), buffer.size());
+	EXPECT_EQ(result.status_lookup_failures, 0u);
+	EXPECT_EQ(result.update_ipv4_on_connect_failures, 0u);
+	EXPECT_EQ(result.map_sends_update_failures, 0u);
+}
+
+TEST(BpfDebugCountersSubtract, computes_per_field_delta) {
+	nettracer::BpfDebugCounters current{};
+	current.status_lookup_failures = 10;
+	current.update_ipv4_on_connect_failures = 5;
+	current.map_sends_update_failures = 100;
+
+	nettracer::BpfDebugCounters previous{};
+	previous.status_lookup_failures = 7;
+	previous.update_ipv4_on_connect_failures = 5;
+	previous.map_sends_update_failures = 80;
+
+	auto delta = nettracer::subtractBpfDebugCounters(current, previous);
+
+	EXPECT_EQ(delta.status_lookup_failures, 3u);
+	EXPECT_EQ(delta.update_ipv4_on_connect_failures, 0u);
+	EXPECT_EQ(delta.map_sends_update_failures, 20u);
+}
+
+TEST(BpfDebugCountersFormat, all_zero_returns_marker) {
+	nettracer::BpfDebugCounters counters{};
+	EXPECT_EQ(nettracer::formatNonZeroFields(counters), "(all zero)");
+}
+
+TEST(BpfDebugCountersFormat, only_non_zero_fields_are_listed) {
+	nettracer::BpfDebugCounters counters{};
+	counters.update_ipv4_on_connect_failures = 1;
+	counters.status_lookup_failures = 42;
+	counters.map_sends_update_failures = 7;
+
+	const auto formatted = nettracer::formatNonZeroFields(counters);
+
+	EXPECT_THAT(formatted, ::testing::HasSubstr("update_ipv4_on_connect_failures=1"));
+	EXPECT_THAT(formatted, ::testing::HasSubstr("status_lookup_failures=42"));
+	EXPECT_THAT(formatted, ::testing::HasSubstr("map_sends_update_failures=7"));
+	EXPECT_THAT(formatted, ::testing::Not(::testing::HasSubstr("update_ipv6_on_connect_failures")));
+	EXPECT_THAT(formatted, ::testing::Not(::testing::HasSubstr("read_ipv4_on_close_failures")));
+}
+
+TEST(BpfDebugCountersFormat, fields_separated_by_single_space) {
+	nettracer::BpfDebugCounters counters{};
+	counters.update_ipv4_on_connect_failures = 1;
+	counters.status_lookup_failures = 2;
+	const auto formatted = nettracer::formatNonZeroFields(counters);
+	EXPECT_EQ(formatted.find("  "), std::string::npos);
+	EXPECT_NE(formatted.find(' '), std::string::npos);
+}
+
+TEST(BpfDebugCountersReader, returns_aggregated_counters_on_successful_lookup) {
+	StubMapsWrapper wrapper;
+	bpf_debug_counters_t cpu0{};
+	cpu0.status_lookup_failures = 4;
+	cpu0.update_ipv4_on_connect_failures = 1;
+	bpf_debug_counters_t cpu1{};
+	cpu1.status_lookup_failures = 6;
+	cpu1.update_ipv4_on_connect_failures = 2;
+	wrapper.perCpuValues = {cpu0, cpu1};
+
+	nettracer::BpfDebugCountersReader reader{/*mapFd=*/42, /*numPossibleCpus=*/2, wrapper};
+	auto result = reader.readAndAggregate();
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->status_lookup_failures, 10u);
+	EXPECT_EQ(result->update_ipv4_on_connect_failures, 3u);
+	EXPECT_EQ(wrapper.lastFd, 42);
+	EXPECT_EQ(wrapper.lastKey, 0u);
+	EXPECT_EQ(wrapper.lookupCallCount, 1);
+}
+
+TEST(BpfDebugCountersReader, returns_nullopt_when_lookup_fails) {
+	StubMapsWrapper wrapper;
+	wrapper.lookupShouldFail = true;
+	wrapper.perCpuValues.resize(2);
+
+	nettracer::BpfDebugCountersReader reader{/*mapFd=*/7, /*numPossibleCpus=*/2, wrapper};
+	auto result = reader.readAndAggregate();
+
+	EXPECT_FALSE(result.has_value());
+}

--- a/libnettracer/test/cpp/bpf_debug_counters_test.cpp
+++ b/libnettracer/test/cpp/bpf_debug_counters_test.cpp
@@ -117,9 +117,9 @@ TEST(BpfDebugCountersSubtract, computes_per_field_delta) {
 	EXPECT_EQ(delta.map_sends_update_failures, 20u);
 }
 
-TEST(BpfDebugCountersFormat, all_zero_returns_marker) {
+TEST(BpfDebugCountersFormat, all_zero_returns_empty_string) {
 	nettracer::BpfDebugCounters counters{};
-	EXPECT_EQ(nettracer::formatNonZeroFields(counters), "(all zero)");
+	EXPECT_EQ(nettracer::formatNonZeroFields(counters), "");
 }
 
 TEST(BpfDebugCountersFormat, only_non_zero_fields_are_listed) {

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -201,8 +201,11 @@ void runDebugCountersLoop(int mapFd, unsigned numPossibleCpus, unsigned interval
 			LOG_WARN("[bpf_debug_counters] lookup failed, skipping interval");
 			continue;
 		}
-		LOG_INFO("[bpf_debug_counters] cumulative: {}", nettracer::formatNonZeroFields(*currentCounters));
-		LOG_INFO("[bpf_debug_counters] delta:      {}", nettracer::formatNonZeroFields(nettracer::subtractBpfDebugCounters(*currentCounters, previousCounters)));
+		const auto cumulativeStr = nettracer::formatNonZeroFields(*currentCounters);
+		const auto deltaStr = nettracer::formatNonZeroFields(nettracer::subtractBpfDebugCounters(*currentCounters, previousCounters));
+		if (!deltaStr.empty()) {
+			LOG_INFO("[bpf_debug_counters] delta:      {}", deltaStr);
+		}
 		previousCounters = *currentCounters;
 	}
 }

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -17,7 +17,9 @@
 #include "bpf_generic/src/bpf_wrapper.h"
 #include "bpf_generic/src/errors.h"
 #include "bpf_generic/src/log.h"
+#include "bpf_generic/src/system_utils.h"
 
+#include "bpf_debug_counters.h"
 #include "bpf_events.h"
 #include "config_watcher.h"
 #include "connections_printing.h"
@@ -75,6 +77,7 @@ po::options_description getOptionsDescription() {
 			("no_stdout_log,n", "Disable logging to stdout, print metrics data in tabular format")
 			("log,l", po::value<std::string>()->default_value(""), "Logger path")
 			("time_interval,t", po::value<unsigned>()->default_value(30), "Time interval of printing metrics data")
+			("debug_counters_interval", po::value<unsigned>()->default_value(300), "Interval (seconds) for logging BPF debug counters; 0 disables")
 			("incremental,i", "Enable incremental data")
 			("noninteractive,r", "Hex output")
 			("with_loopback,f", "With loopback")
@@ -171,6 +174,51 @@ bool isIPv6MonitoringPossible(int status_fd, bpf::BPFMapsWrapper& mapsWrapper) {
 	const uint32_t zero = 0;
 	guess_status_t status;
 	return mapsWrapper.lookupElement(status_fd, &zero, &status) && status.offset_daddr_ipv6 != 0;
+}
+
+unsigned resolveNumPossibleCpus() {
+	if (auto detected = bpf::getNumPossibleCpus(SystemCalls::getInstance())) {
+		return detected.value();
+	}
+	const unsigned hardwareConcurrency{std::thread::hardware_concurrency()};
+	const unsigned fallback{hardwareConcurrency > 0 ? hardwareConcurrency : 1u};
+	LOG_WARN("Could not read /sys/devices/system/cpu/possible, falling back to {}", fallback);
+	return fallback;
+}
+
+void runDebugCountersLoop(int mapFd, unsigned numPossibleCpus, unsigned intervalSeconds, const bpf::BPFMapsWrapper& mapsWrapper) {
+	nettracer::BpfDebugCountersReader reader{mapFd, numPossibleCpus, mapsWrapper};
+	nettracer::BpfDebugCounters previousCounters{};
+	const auto period = std::chrono::seconds(intervalSeconds);
+	while (true) {
+		std::unique_lock<std::mutex> lk{exitCtrl.m};
+		if (exitCtrl.cv.wait_for(lk, period, [] { return !exitCtrl.running; })) {
+			break;
+		}
+		lk.unlock();
+		auto currentCounters = reader.readAndAggregate();
+		if (!currentCounters) {
+			LOG_WARN("[bpf_debug_counters] lookup failed, skipping interval");
+			continue;
+		}
+		LOG_INFO("[bpf_debug_counters] cumulative: {}", nettracer::formatNonZeroFields(*currentCounters));
+		LOG_INFO("[bpf_debug_counters] delta:      {}", nettracer::formatNonZeroFields(nettracer::subtractBpfDebugCounters(*currentCounters, previousCounters)));
+		previousCounters = *currentCounters;
+	}
+}
+
+std::thread startDebugCountersThread(bpf::bpf_subsystem& ebpf, const bpf::BPFMapsWrapper& mapsWrapper, unsigned intervalSeconds) {
+	if (intervalSeconds == 0) {
+		return {};
+	}
+	const int mapFd{ebpf.get_map_fd("bpf_debug_counters")};
+	if (mapFd < 0) {
+		LOG_WARN("bpf_debug_counters map not available, skipping debug counters logging");
+		return {};
+	}
+	const unsigned numPossibleCpus{resolveNumPossibleCpus()};
+	LOG_INFO("Starting BPF debug counters logger (interval={}s, cpus={})", intervalSeconds, numPossibleCpus);
+	return std::thread{runDebugCountersLoop, mapFd, numPossibleCpus, intervalSeconds, std::cref(mapsWrapper)};
 }
 
 enum ReturnCodes {
@@ -331,6 +379,9 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 		bevents.add_observer<tcp_ipv6_event_t>(ipv6_pmap, ipv6_event_update);
 	}
 
+	const unsigned debugCountersInterval{vm["debug_counters_interval"].as<unsigned>()};
+	std::thread debugCountersThread{startDebugCountersThread(ebpf, mapsWrapper, debugCountersInterval)};
+
 	bevents.start();
 	std::promise<bool> map_reader_promise;
 	auto map_reader_future = map_reader_promise.get_future();
@@ -339,6 +390,9 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 	if (map_reader.joinable()) {
 		map_reader.join();
 	};
+	if (debugCountersThread.joinable()) {
+		debugCountersThread.join();
+	}
     bevents.stop();
 	LOG_INFO("Events stopped");
 


### PR DESCRIPTION
Example log output:
2026-05-26 11:26:46.004 [6158] info [nettracer] [bpf_debug_counters] cumulative: read_ipv4_on_close_failures=1 lookup_ipv6_on_close_failures=45
2026-05-26 11:26:46.004 [6158] info [nettracer] [bpf_debug_counters] delta:      read_ipv4_on_close_failures=1 lookup_ipv6_on_close_failures=45