### PR TITLE
Fixing legacy BPF loader

### DIFF
--- a/bpf_generic/src/bpf_interface.h
+++ b/bpf_generic/src/bpf_interface.h
@@ -30,6 +30,7 @@ public:
 	virtual int get_map_fd(const std::string& name) = 0;
 	virtual void clear_all_probes() = 0;
 	virtual map_data get_perf_map(const std::string& name) = 0;
+	virtual bool needs_offset_guessing() const = 0;
 	virtual ~Ibpf() = default;
 };
 

--- a/bpf_generic/src/bpf_wrapper.cpp
+++ b/bpf_generic/src/bpf_wrapper.cpp
@@ -152,13 +152,9 @@ bpf_fds getIPv6Fds(bpf::Ibpf& ebpf) {
 }
 
 bool isIPv6MonitoringPossible(int status_fd, const BPFMapsWrapper& mapsWrapper) {
-#ifdef LEGACY_BPF
 	const uint32_t zero = 0;
 	guess_status_t status;
 	return mapsWrapper.lookupElement(status_fd, &zero, &status) && status.offset_daddr_ipv6 != 0;
-#else
-	return true;
-#endif
 }
 
 } // namespace bpf

--- a/bpf_generic/src/btf_loader.cpp
+++ b/bpf_generic/src/btf_loader.cpp
@@ -61,6 +61,10 @@ void BTFLoader::clear_all_probes() {
 	//handled by kernel at process exit
 }
 
+bool BTFLoader::needs_offset_guessing() const {
+	return false;
+}
+
 BTFLoader::~BTFLoader() {
 	if (skel) {
 		nettracer_bpf_core__detach(skel);

--- a/bpf_generic/src/btf_loader.h
+++ b/bpf_generic/src/btf_loader.h
@@ -38,6 +38,7 @@ public:
 	int get_map_fd(const std::string& name) override;
 	map_data get_perf_map(const std::string& name) override;
 	void clear_all_probes() override;
+	bool needs_offset_guessing() const override;
 	~BTFLoader() override;
 };
 } // namespace bpf

--- a/bpf_generic/src/classic_loader.cpp
+++ b/bpf_generic/src/classic_loader.cpp
@@ -293,6 +293,10 @@ void ClassicLoader::close_all_probes() {
 	probes.clear();
 }
 
+bool ClassicLoader::needs_offset_guessing() const {
+	return true;
+}
+
 void ClassicLoader::close_all_maps() {
 	for (const auto& m : maps) {
 		for (auto fd : m.pfd) {

--- a/bpf_generic/src/classic_loader.h
+++ b/bpf_generic/src/classic_loader.h
@@ -62,6 +62,7 @@ public:
 	int get_map_fd(const std::string& name) override;
 	map_data get_perf_map(const std::string& name) override;
 	void clear_all_probes() override;
+	bool needs_offset_guessing() const override;
 	~ClassicLoader() override;
 };
 

--- a/bpf_generic/src/maps_loading.cpp
+++ b/bpf_generic/src/maps_loading.cpp
@@ -47,9 +47,9 @@ std::string to_string(bpf_map_type type) {
 
 SectionLoader::SectionLoader(const std::string& path){
 
-	auto BufferOrErr = WriteThroughMemoryBuffer::getFile(path.c_str());
+	auto BufferOrErr = MemoryBuffer::getFile(path.c_str());
 	if (!BufferOrErr) {
-		throw std::runtime_error("Error reading file");
+		throw std::runtime_error(fmt::format("Error reading file: {} ({})", strerror(errno), errno));
 	}
 
 	memBufffer.swap(*BufferOrErr);

--- a/bpf_generic/src/maps_loading.h
+++ b/bpf_generic/src/maps_loading.h
@@ -52,7 +52,7 @@ private:
 	} sections{};
 	MapsSymbols mapsRelSymOffsToName;
 
-	std::unique_ptr<llvm::WriteThroughMemoryBuffer> memBufffer;
+	std::unique_ptr<llvm::MemoryBuffer> memBufffer;
 	std::unique_ptr<llvm::object::Binary> binary;
 	llvm::object::ELFObjectFileBase *ELFobj;
 	BpfPrograms bpfPrograms;

--- a/libnettracer/src/system_calls.cpp
+++ b/libnettracer/src/system_calls.cpp
@@ -48,21 +48,27 @@ bool SystemCalls::isKernelSupportedForBTF(int kernelVersion) const {
 	return isKernelSupported(kernelVersion, KERNEL_VERSION_FOR_BTF);
 }
 
-std::pair<std::unique_ptr<bpf::Ibpf>, bool> createBPFinterface(int kernelVersion, std::string_view option, const ISystemCalls& isystem) {
-	if (option == "auto") {
-		if (isystem.isKernelSupportedForBTF(kernelVersion)) {
-			return {bpf::createBTFBPF(), false};
-		}
-		if (!isystem.isKernelSupportedForClassic(kernelVersion)) {
-			LOG_ERROR("Kernel version {} is not supported", kernelVersionToString(kernelVersion));
-			// don't return, see what happens
-		}
-		return {bpf::createOffsetGuessedBPF(), true};
-	} else if (option == "BTF") {
-		return {bpf::createBTFBPF(), false};
-	} else if (option == "offsetguessing") {
-		return {bpf::createOffsetGuessedBPF(), true};
-	}
+std::unique_ptr<bpf::Ibpf> createBPFinterface(int kernelVersion, std::string_view option, const ISystemCalls& isystem) {
+	// @todo: BTF temporarily disabled -> enable
+	// if (option == "auto") {
+	// 	if (isystem.isKernelSupportedForBTF(kernelVersion)) {
+	// 		return bpf::createBTFBPF();
+	// 	}
+	// 	if (!isystem.isKernelSupportedForClassic(kernelVersion)) {
+	// 		LOG_ERROR("Kernel version {} is not supported", kernelVersionToString(kernelVersion));
+	// 		// don't return, see what happens
+	// 	}
+	// 	return bpf::createOffsetGuessedBPF();
+	// } else if (option == "BTF") {
+	// 	return bpf::createBTFBPF();
+	// } else if (option == "offsetguessing") {
+	// 	return bpf::createOffsetGuessedBPF();
+	// }
 
-	return {};
+	// return {};
+	if (!isystem.isKernelSupportedForClassic(kernelVersion)) {
+		LOG_ERROR("Kernel version {} is not supported", kernelVersionToString(kernelVersion));
+		// don't return, see what happens
+	}
+	return bpf::createOffsetGuessedBPF();
 }

--- a/libnettracer/src/system_calls.h
+++ b/libnettracer/src/system_calls.h
@@ -56,4 +56,4 @@ namespace bpf {
 class Ibpf;
 }
 
-std::pair<std::unique_ptr<bpf::Ibpf>, bool> createBPFinterface(int kernelVersion, std::string_view option, const ISystemCalls& isystem);
+std::unique_ptr<bpf::Ibpf> createBPFinterface(int kernelVersion, std::string_view option, const ISystemCalls& isystem);

--- a/libnettracer/test/cpp/system_utils_test.cpp
+++ b/libnettracer/test/cpp/system_utils_test.cpp
@@ -340,34 +340,35 @@ TEST_F(NumPossibleCpusTest, only_whitespace) {
 	EXPECT_FALSE(result);
 }
 
-TEST(CreateBPFInterfaceTest, kernelTooLow) {
-	MockSystemCalls sysCalls;
-	EXPECT_CALL(sysCalls, isKernelSupportedForClassic).WillOnce(Return(false));
-	EXPECT_CALL(sysCalls, isKernelSupportedForBTF).WillOnce(Return(false));
-	auto [ebpf, needsOffsetGuessing] = createBPFinterface(KERNEL_VERSION(4, 14, 0), "auto", sysCalls);
-	EXPECT_TRUE(needsOffsetGuessing);
-	EXPECT_TRUE(dynamic_cast<bpf::ClassicLoader*>(ebpf.get()) != nullptr);
-}
+// @todo: BTF temporarily disabled -> enable
+// TEST(CreateBPFInterfaceTest, kernelTooLow) {
+// 	MockSystemCalls sysCalls;
+// 	EXPECT_CALL(sysCalls, isKernelSupportedForClassic).WillOnce(Return(false));
+// 	EXPECT_CALL(sysCalls, isKernelSupportedForBTF).WillOnce(Return(false));
+// 	auto ebpf = createBPFinterface(KERNEL_VERSION(4, 14, 0), "auto", sysCalls);
+// 	EXPECT_TRUE(ebpf->needs_offset_guessing());
+// 	EXPECT_TRUE(dynamic_cast<bpf::ClassicLoader*>(ebpf.get()) != nullptr);
+// }
 
-TEST(CreateBPFInterfaceTest, kernelForClassic) {
-	MockSystemCalls sysCalls;
-	EXPECT_CALL(sysCalls, isKernelSupportedForClassic).WillOnce(Return(true));
-	EXPECT_CALL(sysCalls, isKernelSupportedForBTF).WillOnce(Return(false));
-	auto [ebpf, needsOffsetGuessing] = createBPFinterface(KERNEL_VERSION(4, 15, 0), "auto", sysCalls);
-	EXPECT_TRUE(needsOffsetGuessing);
-	EXPECT_TRUE(dynamic_cast<bpf::ClassicLoader*>(ebpf.get()) != nullptr);
-}
+// TEST(CreateBPFInterfaceTest, kernelForClassic) {
+// 	MockSystemCalls sysCalls;
+// 	EXPECT_CALL(sysCalls, isKernelSupportedForClassic).WillOnce(Return(true));
+// 	EXPECT_CALL(sysCalls, isKernelSupportedForBTF).WillOnce(Return(false));
+// 	auto ebpf = createBPFinterface(KERNEL_VERSION(4, 15, 0), "auto", sysCalls);
+// 	EXPECT_TRUE(ebpf->needs_offset_guessing());
+// 	EXPECT_TRUE(dynamic_cast<bpf::ClassicLoader*>(ebpf.get()) != nullptr);
+// }
 
-TEST(CreateBPFInterfaceTest, kernelForBTF) {
-	MockSystemCalls sysCalls;
-	EXPECT_CALL(sysCalls, isKernelSupportedForBTF).WillOnce(Return(true));
-	auto [ebpf, needsOffsetGuessing] = createBPFinterface(KERNEL_VERSION(5, 10, 0), "auto", sysCalls);
-	EXPECT_FALSE(needsOffsetGuessing);
-	EXPECT_TRUE(dynamic_cast<bpf::BTFLoader*>(ebpf.get()) != nullptr);
-}
+// TEST(CreateBPFInterfaceTest, kernelForBTF) {
+// 	MockSystemCalls sysCalls;
+// 	EXPECT_CALL(sysCalls, isKernelSupportedForBTF).WillOnce(Return(true));
+// 	auto ebpf = createBPFinterface(KERNEL_VERSION(5, 10, 0), "auto", sysCalls);
+// 	EXPECT_FALSE(ebpf->needs_offset_guessing());
+// 	EXPECT_TRUE(dynamic_cast<bpf::BTFLoader*>(ebpf.get()) != nullptr);
+// }
 
-TEST(CreateBPFInterfaceTest, unexpectedOption) {
-	MockSystemCalls sysCalls;
-	auto [ebpf, needsOffsetGuessing] = createBPFinterface(KERNEL_VERSION(5, 10, 0), "unexpected", sysCalls);
-	EXPECT_FALSE(needsOffsetGuessing);
-}
+// TEST(CreateBPFInterfaceTest, unexpectedOption) {
+// 	MockSystemCalls sysCalls;
+// 	auto ebpf = createBPFinterface(KERNEL_VERSION(5, 10, 0), "unexpected", sysCalls);
+// 	EXPECT_FALSE(ebpf->needs_offset_guessing());
+// }

--- a/nettracersrv/nettracer.cpp
+++ b/nettracersrv/nettracer.cpp
@@ -229,7 +229,7 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 	}
 	LOG_DEBUG("Detected kernel {}", kernelVersionToString(*kernelVersion));
 
-	auto [ebpf, needsOffsetGuessing] = createBPFinterface(*kernelVersion, vm["bpf"].as<std::string>(), SystemCalls::getInstance());
+	auto ebpf = createBPFinterface(*kernelVersion, vm["bpf"].as<std::string>(), SystemCalls::getInstance());
 	if (!ebpf) {
 		LOG_ERROR("Unsuported option for bpf");
 		return ReturnCodes::GenericError;
@@ -269,14 +269,6 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 		return ReturnCodes::InsufficientCapabilities;
 	}
 
-	int status_fd = -1;
-#ifdef LEGACY_BPF
-	status_fd = ebpf->get_map_fd("nettracer_status");
-	if (status_fd < 0) {
-		LOG_ERROR("no fd for status map");
-		return ReturnCodes::GenericError;
-	}
-#endif
 	bpf::bpf_fds ipv4_fds{getIPv4Fds(*ebpf)};
 	if (ipv4_fds.isInvalid()) {
 		LOG_ERROR("invalid fds for ipv4 maps");
@@ -294,12 +286,21 @@ ReturnCodes startNetTracer(config_watcher& cw, boost::program_options::variables
 		return ReturnCodes::Success;
 	}
 
-	if (needsOffsetGuessing && !doOffsetGuessing(status_fd)) {
-		LOG_ERROR("Offset guessing failed");
-		return ReturnCodes::GenericError;
+	bool monitorIPv6 = true;
+	if (ebpf->needs_offset_guessing()) {
+		LOG_INFO("Offset guessing...");
+		auto status_fd = ebpf->get_map_fd("nettracer_status");
+		if (status_fd < 0) {
+			LOG_ERROR("no fd for status map");
+			return ReturnCodes::GenericError;
+		}
+		if (!doOffsetGuessing(status_fd)) {
+			LOG_ERROR("Offset guessing failed");
+			return ReturnCodes::GenericError;
+		}
+		monitorIPv6 = bpf::isIPv6MonitoringPossible(status_fd, mapsWrapper);
+		LOG_INFO(fmt::format("Offset guessing finished: ipv6:{}", monitorIPv6));
 	}
-
-	bool monitorIPv6 = bpf::isIPv6MonitoringPossible(status_fd, mapsWrapper);
 
 	netst.init();
 	bpf_events bevents(cw);


### PR DESCRIPTION
Changed mmap's `prot` arg to PROT_READ. This resolves an issue found in SectionLoader attempting to mmap ELF section w/ PROT_WRITE on read-only fs, resulting in process exit.

Fixed an issue found w/ ClassicLoader, where offset guessing wasn't properly performed, resulting in offset guessing fault, and process exit.

Temporarily disabled BTF loader.